### PR TITLE
Add HuggingFace tokenizer.json format support

### DIFF
--- a/lib/dart_sentencepiece_tokenizer.dart
+++ b/lib/dart_sentencepiece_tokenizer.dart
@@ -15,6 +15,8 @@ export 'src/sentencepiece/sentencepiece_tokenizer.dart'
         SpTruncationConfig,
         SpTruncationDirection,
         ModelType;
+export 'src/sentencepiece/serialization/huggingface_json.dart'
+    show HuggingFaceTokenizerLoader;
 export 'src/sentencepiece/serialization/tokenizer_json.dart'
     show
         SentencePieceTokenizerJson,

--- a/lib/src/sentencepiece/serialization/huggingface_json.dart
+++ b/lib/src/sentencepiece/serialization/huggingface_json.dart
@@ -1,0 +1,519 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../model/model_proto.dart';
+import '../sentencepiece_tokenizer.dart';
+
+/// Metadata extracted from HuggingFace tokenizer.json sections
+/// (added_tokens, normalizer, decoder, post_processor).
+class _HfMetadata {
+  final bool addDummyPrefix;
+  final bool escapeWhitespaces;
+  final bool removeExtraWhitespaces;
+  final bool byteFallback;
+  final int unkId;
+  final int bosId;
+  final int eosId;
+  final int padId;
+  final String unkPiece;
+  final String bosPiece;
+  final String eosPiece;
+  final String padPiece;
+  final bool addBosToken;
+  final bool addEosToken;
+  final List<_HfAddedToken> addedTokens;
+
+  const _HfMetadata({
+    this.addDummyPrefix = true,
+    this.escapeWhitespaces = true,
+    this.removeExtraWhitespaces = false,
+    this.byteFallback = false,
+    this.unkId = 0,
+    this.bosId = 1,
+    this.eosId = 2,
+    this.padId = -1,
+    this.unkPiece = '<unk>',
+    this.bosPiece = '<s>',
+    this.eosPiece = '</s>',
+    this.padPiece = '<pad>',
+    this.addBosToken = false,
+    this.addEosToken = false,
+    this.addedTokens = const [],
+  });
+}
+
+class _HfAddedToken {
+  final int id;
+  final String content;
+  final bool special;
+
+  const _HfAddedToken({
+    required this.id,
+    required this.content,
+    required this.special,
+  });
+}
+
+/// Loader for HuggingFace `tokenizer.json` format.
+///
+/// Supports SentencePiece-based BPE and Unigram models as used by
+/// Gemma, Llama, and similar HuggingFace models.
+class HuggingFaceTokenizerLoader {
+  HuggingFaceTokenizerLoader._();
+
+  /// Create tokenizer from HuggingFace tokenizer.json string.
+  static SentencePieceTokenizer fromJsonString(
+    String json, {
+    SentencePieceConfig? config,
+  }) {
+    final data = jsonDecode(json) as Map<String, dynamic>;
+    return fromMap(data, config: config);
+  }
+
+  /// Create tokenizer from a pre-parsed HuggingFace tokenizer.json map.
+  static SentencePieceTokenizer fromMap(
+    Map<String, dynamic> data, {
+    SentencePieceConfig? config,
+  }) {
+    return _fromJsonMap(data, config);
+  }
+
+  /// Load tokenizer from HuggingFace tokenizer.json file asynchronously.
+  static Future<SentencePieceTokenizer> fromJsonFile(
+    String path, {
+    SentencePieceConfig? config,
+  }) async {
+    final json = await File(path).readAsString();
+    return fromJsonString(json, config: config);
+  }
+
+  /// Load tokenizer from HuggingFace tokenizer.json file synchronously.
+  static SentencePieceTokenizer fromJsonFileSync(
+    String path, {
+    SentencePieceConfig? config,
+  }) {
+    final json = File(path).readAsStringSync();
+    return fromJsonString(json, config: config);
+  }
+
+  static SentencePieceTokenizer _fromJsonMap(
+    Map<String, dynamic> data,
+    SentencePieceConfig? config,
+  ) {
+    final modelData = data['model'] as Map<String, dynamic>?;
+    if (modelData == null) {
+      throw const FormatException(
+        'Missing model section in HuggingFace tokenizer JSON',
+      );
+    }
+
+    final modelType = modelData['type'] as String?;
+    if (modelType == null) {
+      throw const FormatException(
+        'Missing model type in HuggingFace tokenizer JSON',
+      );
+    }
+
+    final meta = _parseMetadata(data);
+
+    final SentencePieceConfig finalConfig;
+    if (config != null) {
+      finalConfig = config;
+    } else {
+      finalConfig = SentencePieceConfig(
+        addBosToken: meta.addBosToken,
+        addEosToken: meta.addEosToken,
+      );
+    }
+
+    final SentencePieceModel model;
+    switch (modelType) {
+      case 'Unigram':
+        model = _parseUnigramModel(modelData, meta);
+      case 'BPE':
+        model = _parseBpeModel(modelData, meta);
+      default:
+        throw UnsupportedError(
+          'Unsupported HuggingFace model type: $modelType. '
+          'Only BPE and Unigram are supported.',
+        );
+    }
+
+    final tokenizer = SentencePieceTokenizer.fromModel(
+      model,
+      config: finalConfig,
+    );
+
+    // Add tokens that are in added_tokens but not in the base vocabulary.
+    _applyAddedTokens(tokenizer, meta, model.vocabSize);
+
+    return tokenizer;
+  }
+
+  static SentencePieceModel _parseUnigramModel(
+    Map<String, dynamic> modelData,
+    _HfMetadata meta,
+  ) {
+    final rawVocab = modelData['vocab'] as List?;
+    if (rawVocab == null) {
+      throw const FormatException(
+        'Missing vocab in HuggingFace Unigram model',
+      );
+    }
+
+    final unkId = modelData['unk_id'] as int? ?? meta.unkId;
+
+    // Build set of special token contents for type detection.
+    final specialContents = <String>{};
+    for (final token in meta.addedTokens) {
+      if (token.special) {
+        specialContents.add(token.content);
+      }
+    }
+
+    final pieces = <SentencePiece>[];
+    for (var i = 0; i < rawVocab.length; i++) {
+      final entry = rawVocab[i] as List;
+      final piece = entry[0] as String;
+      final score = (entry[1] as num).toDouble();
+
+      PieceType type;
+      if (i == unkId) {
+        type = PieceType.unknown;
+      } else if (specialContents.contains(piece)) {
+        type = PieceType.control;
+      } else if (_isByteToken(piece)) {
+        type = PieceType.byte;
+      } else {
+        type = PieceType.normal;
+      }
+
+      pieces.add(SentencePiece(piece: piece, score: score, type: type));
+    }
+
+    return SentencePieceModel(
+      pieces: pieces,
+      trainerSpec: TrainerSpec(
+        modelType: ModelType.unigram,
+        vocabSize: pieces.length,
+        unkId: unkId,
+        bosId: meta.bosId,
+        eosId: meta.eosId,
+        padId: meta.padId,
+        unkPiece: meta.unkPiece,
+        bosPiece: meta.bosPiece,
+        eosPiece: meta.eosPiece,
+        padPiece: meta.padPiece,
+        byteFallback: meta.byteFallback,
+      ),
+      normalizerSpec: NormalizerSpec(
+        name: 'identity',
+        addDummyPrefix: meta.addDummyPrefix,
+        removeExtraWhitespaces: meta.removeExtraWhitespaces,
+        escapeWhitespaces: meta.escapeWhitespaces,
+      ),
+    );
+  }
+
+  static SentencePieceModel _parseBpeModel(
+    Map<String, dynamic> modelData,
+    _HfMetadata meta,
+  ) {
+    final rawVocab = modelData['vocab'] as Map<String, dynamic>?;
+    if (rawVocab == null) {
+      throw const FormatException(
+        'Missing vocab in HuggingFace BPE model',
+      );
+    }
+
+    final rawMerges = modelData['merges'] as List? ?? [];
+    final byteFallback = modelData['byte_fallback'] as bool? ?? meta.byteFallback;
+
+    // Build merge result -> merge index map.
+    final mergeScores = <String, double>{};
+    for (var i = 0; i < rawMerges.length; i++) {
+      final mergeStr = rawMerges[i] as String;
+      final spaceIdx = mergeStr.indexOf(' ');
+      if (spaceIdx < 0) continue;
+      final left = mergeStr.substring(0, spaceIdx);
+      final right = mergeStr.substring(spaceIdx + 1);
+      final merged = left + right;
+      mergeScores[merged] = -i.toDouble();
+    }
+
+    final baseScore = -(rawMerges.length + 1).toDouble();
+
+    // Build set of special token contents for type detection.
+    final specialContents = <String>{};
+    for (final token in meta.addedTokens) {
+      if (token.special) {
+        specialContents.add(token.content);
+      }
+    }
+
+    // Find unk token.
+    final unkToken = modelData['unk_token'] as String? ?? meta.unkPiece;
+
+    // Allocate pieces list indexed by ID.
+    final vocabSize = rawVocab.length;
+    final pieces = List<SentencePiece>.filled(
+      vocabSize,
+      const SentencePiece(piece: ''),
+    );
+
+    for (final entry in rawVocab.entries) {
+      final piece = entry.key;
+      final id = entry.value as int;
+
+      if (id < 0 || id >= vocabSize) continue;
+
+      PieceType type;
+      if (piece == unkToken) {
+        type = PieceType.unknown;
+      } else if (specialContents.contains(piece)) {
+        type = PieceType.control;
+      } else if (_isByteToken(piece)) {
+        type = PieceType.byte;
+      } else {
+        type = PieceType.normal;
+      }
+
+      double score;
+      if (type == PieceType.unknown || type == PieceType.control) {
+        score = 0.0;
+      } else if (mergeScores.containsKey(piece)) {
+        score = mergeScores[piece]!;
+      } else {
+        score = baseScore;
+      }
+
+      pieces[id] = SentencePiece(piece: piece, score: score, type: type);
+    }
+
+    // Determine unk ID from vocab.
+    final unkId = rawVocab[unkToken] as int? ?? meta.unkId;
+
+    return SentencePieceModel(
+      pieces: pieces,
+      trainerSpec: TrainerSpec(
+        modelType: ModelType.bpe,
+        vocabSize: vocabSize,
+        unkId: unkId,
+        bosId: meta.bosId,
+        eosId: meta.eosId,
+        padId: meta.padId,
+        unkPiece: meta.unkPiece,
+        bosPiece: meta.bosPiece,
+        eosPiece: meta.eosPiece,
+        padPiece: meta.padPiece,
+        byteFallback: byteFallback,
+      ),
+      normalizerSpec: NormalizerSpec(
+        name: 'identity',
+        addDummyPrefix: meta.addDummyPrefix,
+        removeExtraWhitespaces: meta.removeExtraWhitespaces,
+        escapeWhitespaces: meta.escapeWhitespaces,
+      ),
+    );
+  }
+
+  static _HfMetadata _parseMetadata(Map<String, dynamic> data) {
+    // Parse added_tokens.
+    final addedTokens = <_HfAddedToken>[];
+    final rawAddedTokens = data['added_tokens'] as List?;
+    if (rawAddedTokens != null) {
+      for (final raw in rawAddedTokens) {
+        final entry = raw as Map<String, dynamic>;
+        addedTokens.add(_HfAddedToken(
+          id: entry['id'] as int,
+          content: entry['content'] as String,
+          special: entry['special'] as bool? ?? false,
+        ));
+      }
+    }
+
+    // Identify special tokens from added_tokens.
+    int unkId = 0;
+    int bosId = 1;
+    int eosId = 2;
+    int padId = -1;
+    String unkPiece = '<unk>';
+    String bosPiece = '<s>';
+    String eosPiece = '</s>';
+    String padPiece = '<pad>';
+
+    for (final token in addedTokens) {
+      if (!token.special) continue;
+      final c = token.content;
+      if (c == '<unk>' || c == '[UNK]') {
+        unkId = token.id;
+        unkPiece = c;
+      } else if (c == '<s>' || c == '<bos>' || c == '[BOS]') {
+        bosId = token.id;
+        bosPiece = c;
+      } else if (c == '</s>' || c == '<eos>' || c == '[EOS]') {
+        eosId = token.id;
+        eosPiece = c;
+      } else if (c == '<pad>' || c == '[PAD]') {
+        padId = token.id;
+        padPiece = c;
+      }
+    }
+
+    // Parse normalizer settings.
+    bool addDummyPrefix = true;
+    bool escapeWhitespaces = true;
+    bool removeExtraWhitespaces = false;
+
+    final normalizerData = data['normalizer'] as Map<String, dynamic>?;
+    if (normalizerData != null) {
+      final parsed = _parseNormalizerFlags(normalizerData);
+      addDummyPrefix = parsed.addDummyPrefix;
+      escapeWhitespaces = parsed.escapeWhitespaces;
+      removeExtraWhitespaces = parsed.removeExtraWhitespaces;
+    }
+
+    // Parse decoder for byte_fallback.
+    bool byteFallback = false;
+    final decoderData = data['decoder'] as Map<String, dynamic>?;
+    if (decoderData != null) {
+      byteFallback = _hasDecoderByteFallback(decoderData);
+    }
+
+    // Parse post_processor for BOS/EOS config.
+    bool addBosToken = false;
+    bool addEosToken = false;
+    final postProcessor = data['post_processor'] as Map<String, dynamic>?;
+    if (postProcessor != null) {
+      final parsed = _parsePostProcessor(postProcessor, bosPiece, eosPiece);
+      addBosToken = parsed.$1;
+      addEosToken = parsed.$2;
+    }
+
+    return _HfMetadata(
+      addDummyPrefix: addDummyPrefix,
+      escapeWhitespaces: escapeWhitespaces,
+      removeExtraWhitespaces: removeExtraWhitespaces,
+      byteFallback: byteFallback,
+      unkId: unkId,
+      bosId: bosId,
+      eosId: eosId,
+      padId: padId,
+      unkPiece: unkPiece,
+      bosPiece: bosPiece,
+      eosPiece: eosPiece,
+      padPiece: padPiece,
+      addBosToken: addBosToken,
+      addEosToken: addEosToken,
+      addedTokens: addedTokens,
+    );
+  }
+
+  static ({bool addDummyPrefix, bool escapeWhitespaces, bool removeExtraWhitespaces})
+      _parseNormalizerFlags(Map<String, dynamic> data) {
+    bool addDummyPrefix = false;
+    bool escapeWhitespaces = false;
+    bool removeExtraWhitespaces = false;
+
+    final type = data['type'] as String?;
+
+    if (type == 'Sequence') {
+      final normalizers = data['normalizers'] as List? ?? [];
+      for (final raw in normalizers) {
+        final n = raw as Map<String, dynamic>;
+        final flags = _parseNormalizerFlags(n);
+        if (flags.addDummyPrefix) addDummyPrefix = true;
+        if (flags.escapeWhitespaces) escapeWhitespaces = true;
+        if (flags.removeExtraWhitespaces) removeExtraWhitespaces = true;
+      }
+    } else if (type == 'Prepend') {
+      final prepend = data['prepend'] as String?;
+      if (prepend == '\u2581' || prepend == ' ') {
+        addDummyPrefix = true;
+      }
+    } else if (type == 'Replace') {
+      final content = data['content'] as String?;
+      if (content == '\u2581') {
+        escapeWhitespaces = true;
+      }
+    }
+
+    return (
+      addDummyPrefix: addDummyPrefix,
+      escapeWhitespaces: escapeWhitespaces,
+      removeExtraWhitespaces: removeExtraWhitespaces,
+    );
+  }
+
+  static bool _hasDecoderByteFallback(Map<String, dynamic> data) {
+    final type = data['type'] as String?;
+    if (type == 'ByteFallback') return true;
+    if (type == 'Sequence') {
+      final decoders = data['decoders'] as List? ?? [];
+      for (final raw in decoders) {
+        if (_hasDecoderByteFallback(raw as Map<String, dynamic>)) return true;
+      }
+    }
+    return false;
+  }
+
+  static (bool, bool) _parsePostProcessor(
+    Map<String, dynamic> data,
+    String bosPiece,
+    String eosPiece,
+  ) {
+    final type = data['type'] as String?;
+    if (type != 'TemplateProcessing') return (false, false);
+
+    bool addBos = false;
+    bool addEos = false;
+
+    final single = data['single'] as List?;
+    if (single != null && single.isNotEmpty) {
+      // Check first element for BOS.
+      final first = single.first as Map<String, dynamic>;
+      if (first.containsKey('SpecialToken')) {
+        final st = first['SpecialToken'] as Map<String, dynamic>;
+        final id = st['id'] as String?;
+        if (id == bosPiece) addBos = true;
+      }
+      // Check last element for EOS.
+      final last = single.last as Map<String, dynamic>;
+      if (last.containsKey('SpecialToken')) {
+        final st = last['SpecialToken'] as Map<String, dynamic>;
+        final id = st['id'] as String?;
+        if (id == eosPiece) addEos = true;
+      }
+    }
+
+    return (addBos, addEos);
+  }
+
+  static void _applyAddedTokens(
+    SentencePieceTokenizer tokenizer,
+    _HfMetadata meta,
+    int baseVocabSize,
+  ) {
+    final normalTokens = <String>[];
+    for (final token in meta.addedTokens) {
+      // Skip tokens already in the base vocabulary.
+      if (token.id < baseVocabSize && tokenizer.vocab.contains(token.content)) {
+        continue;
+      }
+      if (token.special) {
+        tokenizer.vocab.addSpecialToken(token.content);
+      } else {
+        normalTokens.add(token.content);
+      }
+    }
+    if (normalTokens.isNotEmpty) {
+      tokenizer.vocab.addTokens(normalTokens);
+    }
+  }
+
+  static bool _isByteToken(String piece) {
+    return piece.length == 6 &&
+        piece.startsWith('<0x') &&
+        piece.endsWith('>');
+  }
+}

--- a/lib/src/sentencepiece/serialization/huggingface_json.dart
+++ b/lib/src/sentencepiece/serialization/huggingface_json.dart
@@ -4,6 +4,12 @@ import 'dart:io';
 import '../model/model_proto.dart';
 import '../sentencepiece_tokenizer.dart';
 
+/// Known variant strings for each special token type.
+const _unkTokenVariants = {'<unk>', '[UNK]'};
+const _bosTokenVariants = {'<s>', '<bos>', '[BOS]'};
+const _eosTokenVariants = {'</s>', '<eos>', '[EOS]'};
+const _padTokenVariants = {'<pad>', '[PAD]'};
+
 /// Metadata extracted from HuggingFace tokenizer.json sections
 /// (added_tokens, normalizer, decoder, post_processor).
 class _HfMetadata {
@@ -22,6 +28,7 @@ class _HfMetadata {
   final bool addBosToken;
   final bool addEosToken;
   final List<_HfAddedToken> addedTokens;
+  final Set<String> specialContents;
 
   const _HfMetadata({
     this.addDummyPrefix = true,
@@ -39,6 +46,7 @@ class _HfMetadata {
     this.addBosToken = false,
     this.addEosToken = false,
     this.addedTokens = const [],
+    this.specialContents = const {},
   });
 }
 
@@ -75,31 +83,6 @@ class HuggingFaceTokenizerLoader {
     Map<String, dynamic> data, {
     SentencePieceConfig? config,
   }) {
-    return _fromJsonMap(data, config);
-  }
-
-  /// Load tokenizer from HuggingFace tokenizer.json file asynchronously.
-  static Future<SentencePieceTokenizer> fromJsonFile(
-    String path, {
-    SentencePieceConfig? config,
-  }) async {
-    final json = await File(path).readAsString();
-    return fromJsonString(json, config: config);
-  }
-
-  /// Load tokenizer from HuggingFace tokenizer.json file synchronously.
-  static SentencePieceTokenizer fromJsonFileSync(
-    String path, {
-    SentencePieceConfig? config,
-  }) {
-    final json = File(path).readAsStringSync();
-    return fromJsonString(json, config: config);
-  }
-
-  static SentencePieceTokenizer _fromJsonMap(
-    Map<String, dynamic> data,
-    SentencePieceConfig? config,
-  ) {
     final modelData = data['model'] as Map<String, dynamic>?;
     if (modelData == null) {
       throw const FormatException(
@@ -144,10 +127,27 @@ class HuggingFaceTokenizerLoader {
       config: finalConfig,
     );
 
-    // Add tokens that are in added_tokens but not in the base vocabulary.
     _applyAddedTokens(tokenizer, meta, model.vocabSize);
 
     return tokenizer;
+  }
+
+  /// Load tokenizer from HuggingFace tokenizer.json file asynchronously.
+  static Future<SentencePieceTokenizer> fromJsonFile(
+    String path, {
+    SentencePieceConfig? config,
+  }) async {
+    final json = await File(path).readAsString();
+    return fromJsonString(json, config: config);
+  }
+
+  /// Load tokenizer from HuggingFace tokenizer.json file synchronously.
+  static SentencePieceTokenizer fromJsonFileSync(
+    String path, {
+    SentencePieceConfig? config,
+  }) {
+    final json = File(path).readAsStringSync();
+    return fromJsonString(json, config: config);
   }
 
   static SentencePieceModel _parseUnigramModel(
@@ -163,14 +163,6 @@ class HuggingFaceTokenizerLoader {
 
     final unkId = modelData['unk_id'] as int? ?? meta.unkId;
 
-    // Build set of special token contents for type detection.
-    final specialContents = <String>{};
-    for (final token in meta.addedTokens) {
-      if (token.special) {
-        specialContents.add(token.content);
-      }
-    }
-
     final pieces = <SentencePiece>[];
     for (var i = 0; i < rawVocab.length; i++) {
       final entry = rawVocab[i] as List;
@@ -180,7 +172,7 @@ class HuggingFaceTokenizerLoader {
       PieceType type;
       if (i == unkId) {
         type = PieceType.unknown;
-      } else if (specialContents.contains(piece)) {
+      } else if (meta.specialContents.contains(piece)) {
         type = PieceType.control;
       } else if (_isByteToken(piece)) {
         type = PieceType.byte;
@@ -193,25 +185,10 @@ class HuggingFaceTokenizerLoader {
 
     return SentencePieceModel(
       pieces: pieces,
-      trainerSpec: TrainerSpec(
-        modelType: ModelType.unigram,
-        vocabSize: pieces.length,
-        unkId: unkId,
-        bosId: meta.bosId,
-        eosId: meta.eosId,
-        padId: meta.padId,
-        unkPiece: meta.unkPiece,
-        bosPiece: meta.bosPiece,
-        eosPiece: meta.eosPiece,
-        padPiece: meta.padPiece,
-        byteFallback: meta.byteFallback,
+      trainerSpec: _buildTrainerSpec(
+        ModelType.unigram, meta, pieces.length, unkId, meta.byteFallback,
       ),
-      normalizerSpec: NormalizerSpec(
-        name: 'identity',
-        addDummyPrefix: meta.addDummyPrefix,
-        removeExtraWhitespaces: meta.removeExtraWhitespaces,
-        escapeWhitespaces: meta.escapeWhitespaces,
-      ),
+      normalizerSpec: _buildNormalizerSpec(meta),
     );
   }
 
@@ -229,7 +206,6 @@ class HuggingFaceTokenizerLoader {
     final rawMerges = modelData['merges'] as List? ?? [];
     final byteFallback = modelData['byte_fallback'] as bool? ?? meta.byteFallback;
 
-    // Build merge result -> merge index map.
     final mergeScores = <String, double>{};
     for (var i = 0; i < rawMerges.length; i++) {
       final mergeStr = rawMerges[i] as String;
@@ -237,24 +213,12 @@ class HuggingFaceTokenizerLoader {
       if (spaceIdx < 0) continue;
       final left = mergeStr.substring(0, spaceIdx);
       final right = mergeStr.substring(spaceIdx + 1);
-      final merged = left + right;
-      mergeScores[merged] = -i.toDouble();
+      mergeScores[left + right] = -i.toDouble();
     }
 
     final baseScore = -(rawMerges.length + 1).toDouble();
-
-    // Build set of special token contents for type detection.
-    final specialContents = <String>{};
-    for (final token in meta.addedTokens) {
-      if (token.special) {
-        specialContents.add(token.content);
-      }
-    }
-
-    // Find unk token.
     final unkToken = modelData['unk_token'] as String? ?? meta.unkPiece;
 
-    // Allocate pieces list indexed by ID.
     final vocabSize = rawVocab.length;
     final pieces = List<SentencePiece>.filled(
       vocabSize,
@@ -270,7 +234,7 @@ class HuggingFaceTokenizerLoader {
       PieceType type;
       if (piece == unkToken) {
         type = PieceType.unknown;
-      } else if (specialContents.contains(piece)) {
+      } else if (meta.specialContents.contains(piece)) {
         type = PieceType.control;
       } else if (_isByteToken(piece)) {
         type = PieceType.byte;
@@ -281,44 +245,56 @@ class HuggingFaceTokenizerLoader {
       double score;
       if (type == PieceType.unknown || type == PieceType.control) {
         score = 0.0;
-      } else if (mergeScores.containsKey(piece)) {
-        score = mergeScores[piece]!;
       } else {
-        score = baseScore;
+        score = mergeScores[piece] ?? baseScore;
       }
 
       pieces[id] = SentencePiece(piece: piece, score: score, type: type);
     }
 
-    // Determine unk ID from vocab.
     final unkId = rawVocab[unkToken] as int? ?? meta.unkId;
 
     return SentencePieceModel(
       pieces: pieces,
-      trainerSpec: TrainerSpec(
-        modelType: ModelType.bpe,
-        vocabSize: vocabSize,
-        unkId: unkId,
-        bosId: meta.bosId,
-        eosId: meta.eosId,
-        padId: meta.padId,
-        unkPiece: meta.unkPiece,
-        bosPiece: meta.bosPiece,
-        eosPiece: meta.eosPiece,
-        padPiece: meta.padPiece,
-        byteFallback: byteFallback,
+      trainerSpec: _buildTrainerSpec(
+        ModelType.bpe, meta, vocabSize, unkId, byteFallback,
       ),
-      normalizerSpec: NormalizerSpec(
-        name: 'identity',
-        addDummyPrefix: meta.addDummyPrefix,
-        removeExtraWhitespaces: meta.removeExtraWhitespaces,
-        escapeWhitespaces: meta.escapeWhitespaces,
-      ),
+      normalizerSpec: _buildNormalizerSpec(meta),
+    );
+  }
+
+  static TrainerSpec _buildTrainerSpec(
+    ModelType modelType,
+    _HfMetadata meta,
+    int vocabSize,
+    int unkId,
+    bool byteFallback,
+  ) {
+    return TrainerSpec(
+      modelType: modelType,
+      vocabSize: vocabSize,
+      unkId: unkId,
+      bosId: meta.bosId,
+      eosId: meta.eosId,
+      padId: meta.padId,
+      unkPiece: meta.unkPiece,
+      bosPiece: meta.bosPiece,
+      eosPiece: meta.eosPiece,
+      padPiece: meta.padPiece,
+      byteFallback: byteFallback,
+    );
+  }
+
+  static NormalizerSpec _buildNormalizerSpec(_HfMetadata meta) {
+    return NormalizerSpec(
+      name: 'identity',
+      addDummyPrefix: meta.addDummyPrefix,
+      removeExtraWhitespaces: meta.removeExtraWhitespaces,
+      escapeWhitespaces: meta.escapeWhitespaces,
     );
   }
 
   static _HfMetadata _parseMetadata(Map<String, dynamic> data) {
-    // Parse added_tokens.
     final addedTokens = <_HfAddedToken>[];
     final rawAddedTokens = data['added_tokens'] as List?;
     if (rawAddedTokens != null) {
@@ -342,19 +318,21 @@ class HuggingFaceTokenizerLoader {
     String eosPiece = '</s>';
     String padPiece = '<pad>';
 
+    final specialContents = <String>{};
     for (final token in addedTokens) {
       if (!token.special) continue;
+      specialContents.add(token.content);
       final c = token.content;
-      if (c == '<unk>' || c == '[UNK]') {
+      if (_unkTokenVariants.contains(c)) {
         unkId = token.id;
         unkPiece = c;
-      } else if (c == '<s>' || c == '<bos>' || c == '[BOS]') {
+      } else if (_bosTokenVariants.contains(c)) {
         bosId = token.id;
         bosPiece = c;
-      } else if (c == '</s>' || c == '<eos>' || c == '[EOS]') {
+      } else if (_eosTokenVariants.contains(c)) {
         eosId = token.id;
         eosPiece = c;
-      } else if (c == '<pad>' || c == '[PAD]') {
+      } else if (_padTokenVariants.contains(c)) {
         padId = token.id;
         padPiece = c;
       }
@@ -373,14 +351,12 @@ class HuggingFaceTokenizerLoader {
       removeExtraWhitespaces = parsed.removeExtraWhitespaces;
     }
 
-    // Parse decoder for byte_fallback.
     bool byteFallback = false;
     final decoderData = data['decoder'] as Map<String, dynamic>?;
     if (decoderData != null) {
       byteFallback = _hasDecoderByteFallback(decoderData);
     }
 
-    // Parse post_processor for BOS/EOS config.
     bool addBosToken = false;
     bool addEosToken = false;
     final postProcessor = data['post_processor'] as Map<String, dynamic>?;
@@ -406,6 +382,7 @@ class HuggingFaceTokenizerLoader {
       addBosToken: addBosToken,
       addEosToken: addEosToken,
       addedTokens: addedTokens,
+      specialContents: specialContents,
     );
   }
 
@@ -470,14 +447,12 @@ class HuggingFaceTokenizerLoader {
 
     final single = data['single'] as List?;
     if (single != null && single.isNotEmpty) {
-      // Check first element for BOS.
       final first = single.first as Map<String, dynamic>;
       if (first.containsKey('SpecialToken')) {
         final st = first['SpecialToken'] as Map<String, dynamic>;
         final id = st['id'] as String?;
         if (id == bosPiece) addBos = true;
       }
-      // Check last element for EOS.
       final last = single.last as Map<String, dynamic>;
       if (last.containsKey('SpecialToken')) {
         final st = last['SpecialToken'] as Map<String, dynamic>;
@@ -496,7 +471,6 @@ class HuggingFaceTokenizerLoader {
   ) {
     final normalTokens = <String>[];
     for (final token in meta.addedTokens) {
-      // Skip tokens already in the base vocabulary.
       if (token.id < baseVocabSize && tokenizer.vocab.contains(token.content)) {
         continue;
       }

--- a/lib/src/sentencepiece/serialization/tokenizer_json.dart
+++ b/lib/src/sentencepiece/serialization/tokenizer_json.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import '../model/model_proto.dart';
 import '../sentencepiece_tokenizer.dart';
+import 'huggingface_json.dart';
 
 /// JSON schema version for tokenizer serialization.
 const String kTokenizerJsonVersion = '1.0';
@@ -69,8 +70,17 @@ extension SentencePieceTokenizerJson on SentencePieceTokenizer {
 }
 
 /// JSON deserialization for SentencePieceTokenizer.
+///
+/// Supports both the library's own JSON format and HuggingFace
+/// `tokenizer.json` format (auto-detected).
 class TokenizerJsonLoader {
   TokenizerJsonLoader._();
+
+  /// Check if a parsed JSON map is in HuggingFace tokenizer.json format.
+  static bool isHuggingFaceFormat(Map<String, dynamic> data) {
+    final model = data['model'];
+    return model is Map<String, dynamic> && model.containsKey('type');
+  }
 
   /// Create tokenizer from JSON string.
   static SentencePieceTokenizer fromJsonString(
@@ -103,6 +113,11 @@ class TokenizerJsonLoader {
     Map<String, dynamic> data,
     SentencePieceConfig? config,
   ) {
+    // Auto-detect HuggingFace format.
+    if (isHuggingFaceFormat(data)) {
+      return HuggingFaceTokenizerLoader.fromMap(data, config: config);
+    }
+
     // Validate version
     final version = data['version'] as String?;
     if (version == null) {

--- a/test/huggingface_json_test.dart
+++ b/test/huggingface_json_test.dart
@@ -3,10 +3,32 @@ import 'dart:convert';
 import 'package:test/test.dart';
 import 'package:dart_sentencepiece_tokenizer/dart_sentencepiece_tokenizer.dart';
 
-/// Helper to build a minimal HF Unigram tokenizer.json map.
-Map<String, dynamic> _buildHfUnigramJson({
-  List<List<dynamic>>? vocab,
-  int unkId = 0,
+const _defaultAddedTokens = [
+  {'id': 0, 'content': '<unk>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
+  {'id': 1, 'content': '<s>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
+  {'id': 2, 'content': '</s>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
+];
+
+const _defaultNormalizer = {
+  'type': 'Sequence',
+  'normalizers': [
+    {'type': 'Prepend', 'prepend': '\u2581'},
+    {'type': 'Replace', 'pattern': {'Regex': ' '}, 'content': '\u2581'},
+  ],
+};
+
+const _defaultDecoder = {
+  'type': 'Sequence',
+  'decoders': [
+    {'type': 'Replace', 'pattern': {'String': '\u2581'}, 'content': ' '},
+    {'type': 'ByteFallback'},
+    {'type': 'Strip', 'content': ' ', 'start': 1, 'stop': 0},
+  ],
+};
+
+/// Helper to build a minimal HF tokenizer.json map with shared defaults.
+Map<String, dynamic> _buildHfJson({
+  required Map<String, dynamic> model,
   List<Map<String, dynamic>>? addedTokens,
   Map<String, dynamic>? normalizer,
   Map<String, dynamic>? decoder,
@@ -16,32 +38,29 @@ Map<String, dynamic> _buildHfUnigramJson({
     'version': '1.0',
     'truncation': null,
     'padding': null,
-    'added_tokens': addedTokens ??
-        [
-          {'id': 0, 'content': '<unk>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
-          {'id': 1, 'content': '<s>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
-          {'id': 2, 'content': '</s>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
-        ],
-    'normalizer': normalizer ??
-        {
-          'type': 'Sequence',
-          'normalizers': [
-            {'type': 'Prepend', 'prepend': '\u2581'},
-            {'type': 'Replace', 'pattern': {'Regex': ' '}, 'content': '\u2581'},
-          ],
-        },
+    'added_tokens': addedTokens ?? _defaultAddedTokens,
+    'normalizer': normalizer ?? _defaultNormalizer,
     'pre_tokenizer': null,
     'post_processor': postProcessor,
-    'decoder': decoder ??
-        {
-          'type': 'Sequence',
-          'decoders': [
-            {'type': 'Replace', 'pattern': {'String': '\u2581'}, 'content': ' '},
-            {'type': 'ByteFallback'},
-            {'type': 'Strip', 'content': ' ', 'start': 1, 'stop': 0},
-          ],
-        },
-    'model': {
+    'decoder': decoder ?? _defaultDecoder,
+    'model': model,
+  };
+}
+
+Map<String, dynamic> _buildHfUnigramJson({
+  List<List<dynamic>>? vocab,
+  int unkId = 0,
+  List<Map<String, dynamic>>? addedTokens,
+  Map<String, dynamic>? normalizer,
+  Map<String, dynamic>? decoder,
+  Map<String, dynamic>? postProcessor,
+}) {
+  return _buildHfJson(
+    addedTokens: addedTokens,
+    normalizer: normalizer,
+    decoder: decoder,
+    postProcessor: postProcessor,
+    model: {
       'type': 'Unigram',
       'unk_id': unkId,
       'vocab': vocab ??
@@ -66,10 +85,9 @@ Map<String, dynamic> _buildHfUnigramJson({
             ['<0x02>', -100.0],
           ],
     },
-  };
+  );
 }
 
-/// Helper to build a minimal HF BPE tokenizer.json map.
 Map<String, dynamic> _buildHfBpeJson({
   Map<String, int>? vocab,
   List<String>? merges,
@@ -79,36 +97,12 @@ Map<String, dynamic> _buildHfBpeJson({
   Map<String, dynamic>? decoder,
   Map<String, dynamic>? postProcessor,
 }) {
-  return {
-    'version': '1.0',
-    'truncation': null,
-    'padding': null,
-    'added_tokens': addedTokens ??
-        [
-          {'id': 0, 'content': '<unk>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
-          {'id': 1, 'content': '<s>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
-          {'id': 2, 'content': '</s>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
-        ],
-    'normalizer': normalizer ??
-        {
-          'type': 'Sequence',
-          'normalizers': [
-            {'type': 'Prepend', 'prepend': '\u2581'},
-            {'type': 'Replace', 'pattern': {'Regex': ' '}, 'content': '\u2581'},
-          ],
-        },
-    'pre_tokenizer': null,
-    'post_processor': postProcessor,
-    'decoder': decoder ??
-        {
-          'type': 'Sequence',
-          'decoders': [
-            {'type': 'Replace', 'pattern': {'String': '\u2581'}, 'content': ' '},
-            {'type': 'ByteFallback'},
-            {'type': 'Strip', 'content': ' ', 'start': 1, 'stop': 0},
-          ],
-        },
-    'model': {
+  return _buildHfJson(
+    addedTokens: addedTokens,
+    normalizer: normalizer,
+    decoder: decoder,
+    postProcessor: postProcessor,
+    model: {
       'type': 'BPE',
       'dropout': null,
       'unk_token': '<unk>',
@@ -141,7 +135,7 @@ Map<String, dynamic> _buildHfBpeJson({
             '\u2581 Hello',
           ],
     },
-  };
+  );
 }
 
 void main() {

--- a/test/huggingface_json_test.dart
+++ b/test/huggingface_json_test.dart
@@ -1,0 +1,504 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+import 'package:dart_sentencepiece_tokenizer/dart_sentencepiece_tokenizer.dart';
+
+/// Helper to build a minimal HF Unigram tokenizer.json map.
+Map<String, dynamic> _buildHfUnigramJson({
+  List<List<dynamic>>? vocab,
+  int unkId = 0,
+  List<Map<String, dynamic>>? addedTokens,
+  Map<String, dynamic>? normalizer,
+  Map<String, dynamic>? decoder,
+  Map<String, dynamic>? postProcessor,
+}) {
+  return {
+    'version': '1.0',
+    'truncation': null,
+    'padding': null,
+    'added_tokens': addedTokens ??
+        [
+          {'id': 0, 'content': '<unk>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
+          {'id': 1, 'content': '<s>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
+          {'id': 2, 'content': '</s>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
+        ],
+    'normalizer': normalizer ??
+        {
+          'type': 'Sequence',
+          'normalizers': [
+            {'type': 'Prepend', 'prepend': '\u2581'},
+            {'type': 'Replace', 'pattern': {'Regex': ' '}, 'content': '\u2581'},
+          ],
+        },
+    'pre_tokenizer': null,
+    'post_processor': postProcessor,
+    'decoder': decoder ??
+        {
+          'type': 'Sequence',
+          'decoders': [
+            {'type': 'Replace', 'pattern': {'String': '\u2581'}, 'content': ' '},
+            {'type': 'ByteFallback'},
+            {'type': 'Strip', 'content': ' ', 'start': 1, 'stop': 0},
+          ],
+        },
+    'model': {
+      'type': 'Unigram',
+      'unk_id': unkId,
+      'vocab': vocab ??
+          [
+            ['<unk>', 0.0],
+            ['<s>', 0.0],
+            ['</s>', 0.0],
+            ['\u2581', -1.0],
+            ['\u2581Hello', -2.5],
+            ['Hello', -3.0],
+            ['\u2581world', -2.5],
+            ['world', -3.5],
+            ['o', -4.0],
+            ['l', -4.0],
+            ['H', -4.5],
+            ['e', -4.0],
+            ['r', -4.5],
+            ['d', -4.5],
+            ['w', -4.5],
+            ['<0x00>', -100.0],
+            ['<0x01>', -100.0],
+            ['<0x02>', -100.0],
+          ],
+    },
+  };
+}
+
+/// Helper to build a minimal HF BPE tokenizer.json map.
+Map<String, dynamic> _buildHfBpeJson({
+  Map<String, int>? vocab,
+  List<String>? merges,
+  bool byteFallback = true,
+  List<Map<String, dynamic>>? addedTokens,
+  Map<String, dynamic>? normalizer,
+  Map<String, dynamic>? decoder,
+  Map<String, dynamic>? postProcessor,
+}) {
+  return {
+    'version': '1.0',
+    'truncation': null,
+    'padding': null,
+    'added_tokens': addedTokens ??
+        [
+          {'id': 0, 'content': '<unk>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
+          {'id': 1, 'content': '<s>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
+          {'id': 2, 'content': '</s>', 'single_word': false, 'lstrip': false, 'rstrip': false, 'normalized': false, 'special': true},
+        ],
+    'normalizer': normalizer ??
+        {
+          'type': 'Sequence',
+          'normalizers': [
+            {'type': 'Prepend', 'prepend': '\u2581'},
+            {'type': 'Replace', 'pattern': {'Regex': ' '}, 'content': '\u2581'},
+          ],
+        },
+    'pre_tokenizer': null,
+    'post_processor': postProcessor,
+    'decoder': decoder ??
+        {
+          'type': 'Sequence',
+          'decoders': [
+            {'type': 'Replace', 'pattern': {'String': '\u2581'}, 'content': ' '},
+            {'type': 'ByteFallback'},
+            {'type': 'Strip', 'content': ' ', 'start': 1, 'stop': 0},
+          ],
+        },
+    'model': {
+      'type': 'BPE',
+      'dropout': null,
+      'unk_token': '<unk>',
+      'continuing_subword_prefix': null,
+      'end_of_word_suffix': null,
+      'fuse_unk': false,
+      'byte_fallback': byteFallback,
+      'vocab': vocab ??
+          {
+            '<unk>': 0,
+            '<s>': 1,
+            '</s>': 2,
+            '\u2581': 3,
+            'H': 4,
+            'e': 5,
+            'l': 6,
+            'o': 7,
+            'He': 8,
+            'll': 9,
+            'Hell': 10,
+            'Hello': 11,
+            '\u2581Hello': 12,
+          },
+      'merges': merges ??
+          [
+            'H e',
+            'l l',
+            'He ll',
+            'Hell o',
+            '\u2581 Hello',
+          ],
+    },
+  };
+}
+
+void main() {
+  group('HuggingFaceTokenizerLoader', () {
+    group('Unigram model parsing', () {
+      test('loads minimal Unigram tokenizer', () {
+        final json = jsonEncode(_buildHfUnigramJson());
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.vocab.size, 18);
+        expect(tokenizer.modelType, ModelType.unigram);
+      });
+
+      test('correctly identifies special tokens', () {
+        final json = jsonEncode(_buildHfUnigramJson());
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.vocab.unkId, 0);
+        expect(tokenizer.vocab.bosId, 1);
+        expect(tokenizer.vocab.eosId, 2);
+        expect(tokenizer.vocab.unkPiece, '<unk>');
+        expect(tokenizer.vocab.bosPiece, '<s>');
+        expect(tokenizer.vocab.eosPiece, '</s>');
+      });
+
+      test('correctly identifies byte tokens', () {
+        final json = jsonEncode(_buildHfUnigramJson());
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.vocab.isByteToken(15), isTrue); // <0x00>
+        expect(tokenizer.vocab.isByteToken(16), isTrue); // <0x01>
+        expect(tokenizer.vocab.isByteToken(0), isFalse); // <unk>
+      });
+
+      test('preserves vocabulary scores', () {
+        final json = jsonEncode(_buildHfUnigramJson());
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        // Check a normal token score.
+        final helloId = tokenizer.vocab.pieceToId('\u2581Hello');
+        expect(tokenizer.vocab.getScore(helloId), closeTo(-2.5, 0.01));
+      });
+
+      test('detects byte_fallback from decoder', () {
+        final json = jsonEncode(_buildHfUnigramJson());
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.vocab.hasByteFallback, isTrue);
+      });
+
+      test('no byte_fallback when decoder has no ByteFallback', () {
+        final json = jsonEncode(_buildHfUnigramJson(
+          decoder: {
+            'type': 'Sequence',
+            'decoders': [
+              {'type': 'Replace', 'pattern': {'String': '\u2581'}, 'content': ' '},
+            ],
+          },
+        ));
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.vocab.hasByteFallback, isFalse);
+      });
+
+      test('respects explicit config override', () {
+        final json = jsonEncode(_buildHfUnigramJson());
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(
+          json,
+          config: SentencePieceConfig.gemma,
+        );
+
+        expect(tokenizer.config.addBosToken, isTrue);
+        expect(tokenizer.config.addEosToken, isTrue);
+      });
+    });
+
+    group('BPE model parsing', () {
+      test('loads minimal BPE tokenizer', () {
+        final json = jsonEncode(_buildHfBpeJson());
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.vocab.size, 13);
+        expect(tokenizer.modelType, ModelType.bpe);
+      });
+
+      test('assigns scores based on merge order', () {
+        final json = jsonEncode(_buildHfBpeJson());
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        // "He" is merge index 0, should have score -0.0
+        final heId = tokenizer.vocab.pieceToId('He');
+        final heScore = tokenizer.vocab.getScore(heId);
+
+        // "ll" is merge index 1, should have score -1.0
+        final llId = tokenizer.vocab.pieceToId('ll');
+        final llScore = tokenizer.vocab.getScore(llId);
+
+        // Earlier merges should have higher scores.
+        expect(heScore, greaterThan(llScore));
+      });
+
+      test('base tokens get lowest scores', () {
+        final json = jsonEncode(_buildHfBpeJson());
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        // 'H' is a base character, not a merge result.
+        final hId = tokenizer.vocab.pieceToId('H');
+        final hScore = tokenizer.vocab.getScore(hId);
+
+        // 'He' is a merge result.
+        final heId = tokenizer.vocab.pieceToId('He');
+        final heScore = tokenizer.vocab.getScore(heId);
+
+        expect(hScore, lessThan(heScore));
+      });
+
+      test('correctly detects byte_fallback from model data', () {
+        final json = jsonEncode(_buildHfBpeJson(byteFallback: true));
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.vocab.hasByteFallback, isTrue);
+      });
+
+      test('correctly identifies unk token', () {
+        final json = jsonEncode(_buildHfBpeJson());
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.vocab.unkId, 0);
+        expect(tokenizer.vocab.unkPiece, '<unk>');
+      });
+
+      test('handles empty merges list', () {
+        final json = jsonEncode(_buildHfBpeJson(
+          vocab: {
+            '<unk>': 0,
+            '<s>': 1,
+            '</s>': 2,
+            'a': 3,
+            'b': 4,
+          },
+          merges: [],
+        ));
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.vocab.size, 5);
+        expect(tokenizer.modelType, ModelType.bpe);
+      });
+    });
+
+    group('normalizer inference', () {
+      test('detects addDummyPrefix from Prepend normalizer', () {
+        final json = jsonEncode(_buildHfUnigramJson(
+          normalizer: {
+            'type': 'Prepend',
+            'prepend': '\u2581',
+          },
+        ));
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.normalizer.addDummyPrefix, isTrue);
+      });
+
+      test('detects escapeWhitespaces from Replace normalizer', () {
+        final json = jsonEncode(_buildHfUnigramJson(
+          normalizer: {
+            'type': 'Replace',
+            'pattern': {'Regex': ' '},
+            'content': '\u2581',
+          },
+        ));
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.normalizer.escapeWhitespaces, isTrue);
+      });
+
+      test('handles null normalizer with defaults', () {
+        final json = jsonEncode(_buildHfUnigramJson(normalizer: null));
+        // Need to set it to null explicitly in the map.
+        final data = jsonDecode(json) as Map<String, dynamic>;
+        data['normalizer'] = null;
+        final tokenizer = HuggingFaceTokenizerLoader.fromMap(data);
+
+        // Default when null: addDummyPrefix=true, escapeWhitespaces=true
+        expect(tokenizer.normalizer.addDummyPrefix, isTrue);
+        expect(tokenizer.normalizer.escapeWhitespaces, isTrue);
+      });
+    });
+
+    group('post_processor config inference', () {
+      test('detects addBosToken from TemplateProcessing', () {
+        final json = jsonEncode(_buildHfUnigramJson(
+          postProcessor: {
+            'type': 'TemplateProcessing',
+            'single': [
+              {'SpecialToken': {'id': '<s>', 'type_id': 0}},
+              {'Sequence': {'id': 'A', 'type_id': 0}},
+            ],
+            'pair': [],
+            'special_tokens': {},
+          },
+        ));
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.config.addBosToken, isTrue);
+        expect(tokenizer.config.addEosToken, isFalse);
+      });
+
+      test('detects addBosToken and addEosToken', () {
+        final json = jsonEncode(_buildHfUnigramJson(
+          postProcessor: {
+            'type': 'TemplateProcessing',
+            'single': [
+              {'SpecialToken': {'id': '<s>', 'type_id': 0}},
+              {'Sequence': {'id': 'A', 'type_id': 0}},
+              {'SpecialToken': {'id': '</s>', 'type_id': 0}},
+            ],
+            'pair': [],
+            'special_tokens': {},
+          },
+        ));
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        expect(tokenizer.config.addBosToken, isTrue);
+        expect(tokenizer.config.addEosToken, isTrue);
+      });
+
+      test('no special tokens inferred without post_processor', () {
+        final json = jsonEncode(_buildHfUnigramJson(postProcessor: null));
+        final data = jsonDecode(json) as Map<String, dynamic>;
+        data['post_processor'] = null;
+        final tokenizer = HuggingFaceTokenizerLoader.fromMap(data);
+
+        expect(tokenizer.config.addBosToken, isFalse);
+        expect(tokenizer.config.addEosToken, isFalse);
+      });
+    });
+
+    group('added_tokens handling', () {
+      test('extra added_tokens beyond base vocab are added', () {
+        final json = jsonEncode(_buildHfUnigramJson(
+          addedTokens: [
+            {'id': 0, 'content': '<unk>', 'special': true},
+            {'id': 1, 'content': '<s>', 'special': true},
+            {'id': 2, 'content': '</s>', 'special': true},
+            {'id': 99999, 'content': '<mask>', 'special': true},
+          ],
+        ));
+        final tokenizer = HuggingFaceTokenizerLoader.fromJsonString(json);
+
+        // <mask> should be added as a special token.
+        expect(tokenizer.vocab.contains('<mask>'), isTrue);
+      });
+    });
+
+    group('auto-detection via TokenizerJsonLoader', () {
+      test('HF format is auto-detected', () {
+        final json = jsonEncode(_buildHfUnigramJson());
+        final tokenizer = TokenizerJsonLoader.fromJsonString(json);
+
+        expect(tokenizer.modelType, ModelType.unigram);
+        expect(tokenizer.vocab.size, 18);
+      });
+
+      test('isHuggingFaceFormat returns true for HF format', () {
+        final data = _buildHfUnigramJson();
+        expect(TokenizerJsonLoader.isHuggingFaceFormat(data), isTrue);
+      });
+
+      test('isHuggingFaceFormat returns false for custom format', () {
+        final data = {
+          'version': '1.0',
+          'model_type': 'unigram',
+          'vocab': {
+            'pieces': ['a'],
+            'scores': [1.0],
+            'types': [1],
+          },
+          'special_tokens': {
+            'unk': {'id': 0, 'piece': '<unk>'},
+            'bos': {'id': 1, 'piece': '<s>'},
+            'eos': {'id': 2, 'piece': '</s>'},
+            'pad': {'id': -1, 'piece': '<pad>'},
+          },
+          'normalizer': {
+            'add_dummy_prefix': true,
+            'remove_extra_whitespaces': true,
+            'escape_whitespaces': true,
+          },
+        };
+        expect(TokenizerJsonLoader.isHuggingFaceFormat(data), isFalse);
+      });
+    });
+
+    group('error handling', () {
+      test('missing model section throws FormatException', () {
+        final json = jsonEncode({
+          'version': '1.0',
+          'added_tokens': [],
+        });
+
+        expect(
+          () => HuggingFaceTokenizerLoader.fromJsonString(json),
+          throwsFormatException,
+        );
+      });
+
+      test('missing model type throws FormatException', () {
+        final json = jsonEncode({
+          'version': '1.0',
+          'added_tokens': [],
+          'model': {'vocab': []},
+        });
+
+        expect(
+          () => HuggingFaceTokenizerLoader.fromJsonString(json),
+          throwsFormatException,
+        );
+      });
+
+      test('unsupported model type throws UnsupportedError', () {
+        final json = jsonEncode({
+          'version': '1.0',
+          'added_tokens': [],
+          'model': {'type': 'WordPiece', 'vocab': {}},
+        });
+
+        expect(
+          () => HuggingFaceTokenizerLoader.fromJsonString(json),
+          throwsA(isA<UnsupportedError>()),
+        );
+      });
+
+      test('missing Unigram vocab throws FormatException', () {
+        final json = jsonEncode({
+          'version': '1.0',
+          'added_tokens': [],
+          'model': {'type': 'Unigram', 'unk_id': 0},
+        });
+
+        expect(
+          () => HuggingFaceTokenizerLoader.fromJsonString(json),
+          throwsFormatException,
+        );
+      });
+
+      test('missing BPE vocab throws FormatException', () {
+        final json = jsonEncode({
+          'version': '1.0',
+          'added_tokens': [],
+          'model': {'type': 'BPE', 'merges': []},
+        });
+
+        expect(
+          () => HuggingFaceTokenizerLoader.fromJsonString(json),
+          throwsFormatException,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Add support for loading tokenizers from HuggingFace's `tokenizer.json` format, enabling compatibility with models like Gemma and Llama that use this format instead of the native SentencePiece binary format.

## Key Changes
- **New HuggingFaceTokenizerLoader class**: Implements parsing of HuggingFace `tokenizer.json` files with support for:
  - Unigram and BPE model types
  - Automatic detection and configuration of special tokens (unk, bos, eos, pad)
  - Normalizer settings inference (addDummyPrefix, escapeWhitespaces)
  - Post-processor configuration parsing (addBosToken, addEosToken)
  - Byte fallback detection from decoder configuration
  - Added tokens handling beyond base vocabulary
  - Both synchronous and asynchronous file loading

- **Auto-detection in TokenizerJsonLoader**: Extended the existing loader to automatically detect and delegate to HuggingFaceTokenizerLoader when appropriate, with `isHuggingFaceFormat()` helper method

- **Comprehensive test coverage**: Added 498 lines of tests covering:
  - Unigram and BPE model parsing
  - Special token identification and byte token detection
  - Vocabulary score preservation
  - Normalizer and post-processor inference
  - Error handling for malformed inputs
  - Auto-detection via TokenizerJsonLoader

- **Public API exports**: Exposed HuggingFaceTokenizerLoader in the main package exports

## Implementation Details
- Metadata extraction from HuggingFace JSON sections (added_tokens, normalizer, decoder, post_processor) is centralized in `_parseMetadata()`
- BPE merge scores are computed based on merge order (earlier merges get higher scores)
- Special token variants (e.g., `<unk>`, `[UNK]`) are recognized and mapped to their IDs
- Byte tokens (format: `<0xHH>`) are automatically identified and typed as `PieceType.byte`
- Graceful fallback to sensible defaults when optional HuggingFace sections are missing

https://claude.ai/code/session_01Qt65mqTaXaENRyhCKQYjzJ