### PR TITLE
docs: prepare v1.3.2 release - CHANGELOG, README, and pubspec updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-04-07
+
+### Added
+
+- **GitHub Actions CI Pipeline** (#9, #19)
+  - `analyze` job - `dart format --set-exit-if-changed` and `dart analyze --fatal-infos`
+  - `test` job - Matrix testing across Dart stable and 3.10.7 (minimum supported version)
+  - Minimal permissions (`contents: read`) and concurrency group to cancel stale runs
+
+### Changed
+
+- Applied `dart format` to 23 files for consistent code style
+- Resolved all `dart analyze --fatal-infos` issues
+  - Removed deprecated `avoid_returning_null_for_future` lint rule
+  - Added curly braces to if statements, `const` constructors, `final` local variables
+- Added documentation comments clarifying `google/sentencepiece` proto spec compliance for default token IDs (`unkId=0, bosId=1, eosId=2, padId=-1`) (#20)
+
 ## [1.3.1] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # dart_sentencepiece_tokenizer
 
+![CI](https://github.com/brody-0125/dart_sentencepiece_tokenizer/actions/workflows/ci.yml/badge.svg)
 ![Dart](https://img.shields.io/badge/Dart-3.10.7+-0175C2.svg?logo=dart)
 ![License](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Hugging Face](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Compatible-FF6600)
@@ -17,13 +18,14 @@ A lightweight, pure Dart implementation of SentencePiece tokenizer. Supports BPE
 - **Streaming API** - HuggingFace TextStreamer compatible for real-time LLM output
 - **HuggingFace Compatible** - JSON serialization, dynamic token addition, tokenize() API
 - **HuggingFace tokenizer.json** - Load tokenizers directly from HuggingFace `tokenizer.json` format
-- **Well Tested** - 274+ tests with 100% pass rate
+- **CI/CD** - GitHub Actions with format check, lint, and multi-version testing
+- **Well Tested** - 302+ tests with 100% pass rate
 
 ## Installation
 
 ```yaml
 dependencies:
-  dart_sentencepiece_tokenizer: ^1.3.1
+  dart_sentencepiece_tokenizer: ^1.3.2
 ```
 
 ## Quick Start
@@ -509,7 +511,7 @@ Download SentencePiece models from HuggingFace:
 ## Testing
 
 ```bash
-# Run all tests (274 tests)
+# Run all tests (302+ tests)
 dart test
 
 # Run specific test file

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_sentencepiece_tokenizer
 description: A lightweight, pure Dart implementation of SentencePiece tokenizer. Supports BPE (Gemma) and Unigram (Llama) algorithms.
-version: 1.3.1
+version: 1.3.2
 repository: https://github.com/brody-0125/dart_sentencepiece_tokenizer
 issue_tracker: https://github.com/brody-0125/dart_sentencepiece_tokenizer/issues
 topics:


### PR DESCRIPTION
Add v1.3.2 CHANGELOG entry covering CI pipeline (#9, #19), code quality improvements (dart format/analyze), and proto spec documentation (#20). Update pubspec version to 1.3.2, add CI badge, and update test counts in README.

https://claude.ai/code/session_01U2kHmQb1riHPcZbPNFopVP