### PR TITLE
feat: add Unicode normalization via precompiled charsmap (DARTS trie)

### DIFF
--- a/lib/src/sentencepiece/normalizer/precompiled_charsmap.dart
+++ b/lib/src/sentencepiece/normalizer/precompiled_charsmap.dart
@@ -96,51 +96,43 @@ class PrecompiledCharsmap {
   ///
   /// Returns (matchLength, normalizedStringOffset) or null if no match.
   (int, int)? _longestPrefixMatch(Uint8List input, int start) {
+    final arrayLen = _array.length;
     var nodePos = 0;
     var unit = _array[0];
     nodePos ^= _offset(unit);
 
-    int? longestLength;
-    int? longestValue;
+    var longestLength = 0;
+    var longestValue = 0;
 
     for (var i = start; i < input.length; i++) {
       final c = input[i];
 
-      // Transition: move to child node for byte c
       nodePos ^= c;
-      if (nodePos >= _array.length) break;
+      if (nodePos >= arrayLen) break;
 
       unit = _array[nodePos];
       if (_label(unit) != c) break;
 
-      // Move to the base of this node's children
       nodePos ^= _offset(unit);
 
-      // Check if this node has an output value (leaf)
       if (_hasLeaf(unit)) {
-        if (nodePos >= _array.length) break;
-        final leafUnit = _array[nodePos];
-        final value = _value(leafUnit);
-        final length = i - start + 1;
-        if (longestLength == null || length > longestLength) {
-          longestLength = length;
-          longestValue = value;
-        }
+        if (nodePos >= arrayLen) break;
+        longestValue = _value(_array[nodePos]);
+        longestLength = i - start + 1;
       }
     }
 
-    if (longestLength != null && longestValue != null) {
-      return (longestLength, longestValue);
-    }
-    return null;
+    return longestLength > 0 ? (longestLength, longestValue) : null;
   }
 
   /// Append the null-terminated normalized string at [offset] to [output].
   void _appendNormalizedString(BytesBuilder output, int offset) {
-    var i = offset;
-    while (i < _normalized.length && _normalized[i] != 0) {
-      output.addByte(_normalized[i]);
-      i++;
+    var end = offset;
+    while (end < _normalized.length && _normalized[end] != 0) {
+      end++;
+    }
+    if (end > offset) {
+      output.add(Uint8List.sublistView(_normalized, offset, end));
     }
   }
 

--- a/lib/src/sentencepiece/normalizer/precompiled_charsmap.dart
+++ b/lib/src/sentencepiece/normalizer/precompiled_charsmap.dart
@@ -1,0 +1,175 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Decoder for SentencePiece's precompiled character normalization map.
+///
+/// The precompiled charsmap is a binary blob containing a DARTS
+/// (Double-ARray Trie System) trie and a normalized string pool.
+/// It encodes string-to-string mappings used for NFKC-like normalization.
+///
+/// Binary format:
+/// - Bytes 0-3: trie blob size (little-endian uint32)
+/// - Bytes 4..(4+trieBlobSize-1): DARTS double-array trie (uint32 units)
+/// - Remaining bytes: null-terminated UTF-8 normalized string pool
+class PrecompiledCharsmap {
+  final Uint32List _array;
+  final Uint8List _normalized;
+
+  PrecompiledCharsmap._(this._array, this._normalized);
+
+  /// Parse a precompiled charsmap from its binary representation.
+  factory PrecompiledCharsmap.fromBytes(Uint8List data) {
+    if (data.length < 4) {
+      throw FormatException(
+        'Precompiled charsmap too short: ${data.length} bytes',
+      );
+    }
+
+    final byteData = ByteData.sublistView(data);
+    final trieBlobSize = byteData.getUint32(0, Endian.little);
+
+    if (4 + trieBlobSize > data.length) {
+      throw FormatException(
+        'Trie blob size ($trieBlobSize) exceeds data length (${data.length - 4})',
+      );
+    }
+
+    if (trieBlobSize % 4 != 0) {
+      throw FormatException(
+        'Trie blob size ($trieBlobSize) is not a multiple of 4',
+      );
+    }
+
+    // Parse DARTS double-array (little-endian uint32 units)
+    final numUnits = trieBlobSize ~/ 4;
+    final array = Uint32List(numUnits);
+    final trieByteData = ByteData.sublistView(data, 4, 4 + trieBlobSize);
+    for (var i = 0; i < numUnits; i++) {
+      array[i] = trieByteData.getUint32(i * 4, Endian.little);
+    }
+
+    // Normalized string pool (null-terminated UTF-8 strings)
+    final normalized = Uint8List.sublistView(data, 4 + trieBlobSize);
+
+    return PrecompiledCharsmap._(array, normalized);
+  }
+
+  /// Apply the precompiled charsmap normalization to [input].
+  ///
+  /// Uses leftmost-longest matching via the DARTS trie.
+  /// Characters not matched by the trie pass through unchanged.
+  /// Invalid UTF-8 bytes are replaced with U+FFFD.
+  String normalize(String input) {
+    if (input.isEmpty || _array.isEmpty) return input;
+
+    final inputBytes = utf8.encode(input);
+    final output = BytesBuilder(copy: false);
+
+    var pos = 0;
+    while (pos < inputBytes.length) {
+      final match = _longestPrefixMatch(inputBytes, pos);
+
+      if (match != null) {
+        final (matchLength, normalizedOffset) = match;
+        _appendNormalizedString(output, normalizedOffset);
+        pos += matchLength;
+      } else {
+        // No match: copy one UTF-8 character unchanged
+        final charLen = _utf8CharLength(inputBytes[pos]);
+        if (charLen > 0 && pos + charLen <= inputBytes.length) {
+          for (var i = 0; i < charLen; i++) {
+            output.addByte(inputBytes[pos + i]);
+          }
+          pos += charLen;
+        } else {
+          // Invalid UTF-8: emit U+FFFD replacement character
+          output.add(const [0xEF, 0xBF, 0xBD]);
+          pos++;
+        }
+      }
+    }
+
+    return utf8.decode(output.takeBytes(), allowMalformed: true);
+  }
+
+  /// Find the longest prefix match starting at [start] in [input].
+  ///
+  /// Returns (matchLength, normalizedStringOffset) or null if no match.
+  (int, int)? _longestPrefixMatch(Uint8List input, int start) {
+    var nodePos = 0;
+    var unit = _array[0];
+    nodePos ^= _offset(unit);
+
+    int? longestLength;
+    int? longestValue;
+
+    for (var i = start; i < input.length; i++) {
+      final c = input[i];
+
+      // Transition: move to child node for byte c
+      nodePos ^= c;
+      if (nodePos >= _array.length) break;
+
+      unit = _array[nodePos];
+      if (_label(unit) != c) break;
+
+      // Move to the base of this node's children
+      nodePos ^= _offset(unit);
+
+      // Check if this node has an output value (leaf)
+      if (_hasLeaf(unit)) {
+        if (nodePos >= _array.length) break;
+        final leafUnit = _array[nodePos];
+        final value = _value(leafUnit);
+        final length = i - start + 1;
+        if (longestLength == null || length > longestLength) {
+          longestLength = length;
+          longestValue = value;
+        }
+      }
+    }
+
+    if (longestLength != null && longestValue != null) {
+      return (longestLength, longestValue);
+    }
+    return null;
+  }
+
+  /// Append the null-terminated normalized string at [offset] to [output].
+  void _appendNormalizedString(BytesBuilder output, int offset) {
+    var i = offset;
+    while (i < _normalized.length && _normalized[i] != 0) {
+      output.addByte(_normalized[i]);
+      i++;
+    }
+  }
+
+  // ---- DARTS double-array unit field accessors ----
+
+  /// Whether this unit has a leaf (value) node at its base offset.
+  bool _hasLeaf(int unit) => ((unit >> 8) & 1) == 1;
+
+  /// Extract the value from a leaf unit (bits 0-30).
+  int _value(int unit) => unit & 0x7FFFFFFF;
+
+  /// Extract the label from a unit (bit 31 + bits 0-7).
+  /// For internal nodes, bit 31 is 0 so this returns the byte label (0-255).
+  /// For leaf units, bit 31 is set, preventing false label matches.
+  int _label(int unit) => unit & 0x800000FF;
+
+  /// Extract the offset (base address) from a unit.
+  /// Uses a two-level encoding: bit 9 selects between 22-bit and 30-bit offsets.
+  int _offset(int unit) {
+    return (unit >> 10) << ((unit & (1 << 9)) >> 6);
+  }
+
+  /// Returns the byte length of a UTF-8 character starting with [byte].
+  /// Returns 0 for invalid lead bytes.
+  static int _utf8CharLength(int byte) {
+    if (byte < 0x80) return 1;
+    if ((byte & 0xE0) == 0xC0) return 2;
+    if ((byte & 0xF0) == 0xE0) return 3;
+    if ((byte & 0xF8) == 0xF0) return 4;
+    return 0;
+  }
+}

--- a/lib/src/sentencepiece/normalizer/sp_normalizer.dart
+++ b/lib/src/sentencepiece/normalizer/sp_normalizer.dart
@@ -1,4 +1,7 @@
+import 'dart:typed_data';
+
 import '../model/model_proto.dart';
+import 'precompiled_charsmap.dart';
 
 /// SentencePiece whitespace replacement character.
 const String kSpaceSymbol = '\u2581'; // ▁ (Lower One Eighth Block)
@@ -7,39 +10,65 @@ class SpNormalizer {
   final bool addDummyPrefix;
   final bool removeExtraWhitespaces;
   final bool escapeWhitespaces;
+  final String normalizerName;
+  final PrecompiledCharsmap? _charsmap;
+  final Uint8List? _precompiledCharsmapBytes;
 
-  const SpNormalizer({
+  SpNormalizer({
     this.addDummyPrefix = true,
     this.removeExtraWhitespaces = true,
     this.escapeWhitespaces = true,
-  });
+    this.normalizerName = '',
+    PrecompiledCharsmap? charsmap,
+    Uint8List? precompiledCharsmapBytes,
+  }) : _charsmap = charsmap,
+       _precompiledCharsmapBytes = precompiledCharsmapBytes;
 
   factory SpNormalizer.fromSpec(NormalizerSpec spec) {
+    PrecompiledCharsmap? charsmap;
+    final charsmapBytes = spec.precompiledCharsmap;
+    if (charsmapBytes != null && charsmapBytes.isNotEmpty) {
+      charsmap = PrecompiledCharsmap.fromBytes(charsmapBytes);
+    }
     return SpNormalizer(
       addDummyPrefix: spec.addDummyPrefix,
       removeExtraWhitespaces: spec.removeExtraWhitespaces,
       escapeWhitespaces: spec.escapeWhitespaces,
+      normalizerName: spec.name,
+      charsmap: charsmap,
+      precompiledCharsmapBytes: charsmapBytes,
     );
   }
+
+  /// Whether this normalizer has a precompiled charsmap.
+  bool get hasCharsmap => _charsmap != null;
+
+  /// Raw precompiled charsmap bytes for serialization.
+  Uint8List? get precompiledCharsmapBytes => _precompiledCharsmapBytes;
 
   String normalize(String text) {
     if (text.isEmpty) return text;
 
     var result = text;
 
-    // Step 1: Remove extra whitespaces
+    // Step 1: Apply precompiled charsmap normalization (NFKC-like)
+    if (_charsmap case final charsmap?) {
+      result = charsmap.normalize(result);
+    }
+
+    // Step 2: Remove extra whitespaces
     if (removeExtraWhitespaces) {
       result = _collapseWhitespaces(result);
     }
 
-    // Step 2: Add dummy prefix (space at beginning)
+    // Step 3: Add dummy prefix (space at beginning)
     if (addDummyPrefix &&
         result.isNotEmpty &&
         !_isWhitespace(result.codeUnitAt(0))) {
       result = ' $result';
     }
 
-    // Step 3: Escape whitespaces (replace space with ▁)
+    // Step 4: Escape whitespaces (replace space with ▁)
     if (escapeWhitespaces) {
       result = result.replaceAll(' ', kSpaceSymbol);
     }
@@ -111,5 +140,7 @@ class SpNormalizer {
       'SpNormalizer('
       'addDummyPrefix: $addDummyPrefix, '
       'removeExtraWhitespaces: $removeExtraWhitespaces, '
-      'escapeWhitespaces: $escapeWhitespaces)';
+      'escapeWhitespaces: $escapeWhitespaces, '
+      'normalizerName: $normalizerName, '
+      'hasCharsmap: $hasCharsmap)';
 }

--- a/lib/src/sentencepiece/sentencepiece_tokenizer.dart
+++ b/lib/src/sentencepiece/sentencepiece_tokenizer.dart
@@ -928,8 +928,10 @@ class _SerializableModelData {
   final bool addDummyPrefix;
   final bool removeExtraWhitespaces;
   final bool escapeWhitespaces;
+  final String normalizerName;
+  final Uint8List? precompiledCharsmapBytes;
 
-  const _SerializableModelData({
+  _SerializableModelData({
     required this.pieces,
     required this.scores,
     required this.types,
@@ -946,6 +948,8 @@ class _SerializableModelData {
     required this.addDummyPrefix,
     required this.removeExtraWhitespaces,
     required this.escapeWhitespaces,
+    required this.normalizerName,
+    this.precompiledCharsmapBytes,
   });
 
   factory _SerializableModelData.fromTokenizer(
@@ -971,6 +975,8 @@ class _SerializableModelData {
       addDummyPrefix: tokenizer._normalizer.addDummyPrefix,
       removeExtraWhitespaces: tokenizer._normalizer.removeExtraWhitespaces,
       escapeWhitespaces: tokenizer._normalizer.escapeWhitespaces,
+      normalizerName: tokenizer._normalizer.normalizerName,
+      precompiledCharsmapBytes: tokenizer._normalizer.precompiledCharsmapBytes,
     );
   }
 
@@ -1003,7 +1009,8 @@ class _SerializableModelData {
         byteFallback: byteFallback,
       ),
       normalizerSpec: NormalizerSpec(
-        name: 'identity',
+        name: normalizerName,
+        precompiledCharsmap: precompiledCharsmapBytes,
         addDummyPrefix: addDummyPrefix,
         removeExtraWhitespaces: removeExtraWhitespaces,
         escapeWhitespaces: escapeWhitespaces,

--- a/lib/src/sentencepiece/serialization/tokenizer_json.dart
+++ b/lib/src/sentencepiece/serialization/tokenizer_json.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import '../model/model_proto.dart';
 import '../sentencepiece_tokenizer.dart';
@@ -58,6 +59,10 @@ extension SentencePieceTokenizerJson on SentencePieceTokenizer {
         'add_dummy_prefix': normalizer.addDummyPrefix,
         'remove_extra_whitespaces': normalizer.removeExtraWhitespaces,
         'escape_whitespaces': normalizer.escapeWhitespaces,
+        'normalizer_name': normalizer.normalizerName,
+        if (normalizer.precompiledCharsmapBytes != null)
+          'precompiled_charsmap':
+              base64Encode(normalizer.precompiledCharsmapBytes!),
       },
       'config': {
         'add_bos_token': config.addBosToken,
@@ -182,6 +187,13 @@ class TokenizerJsonLoader {
         normalizerData['remove_extra_whitespaces'] as bool? ?? true;
     final escapeWhitespaces =
         normalizerData['escape_whitespaces'] as bool? ?? true;
+    final normalizerName =
+        normalizerData['normalizer_name'] as String? ?? '';
+    Uint8List? precompiledCharsmap;
+    final charsmapB64 = normalizerData['precompiled_charsmap'] as String?;
+    if (charsmapB64 != null) {
+      precompiledCharsmap = base64Decode(charsmapB64);
+    }
 
     // Parse byte fallback
     final byteFallback = data['byte_fallback'] as bool? ?? false;
@@ -231,7 +243,8 @@ class TokenizerJsonLoader {
         byteFallback: byteFallback,
       ),
       normalizerSpec: NormalizerSpec(
-        name: 'identity',
+        name: normalizerName,
+        precompiledCharsmap: precompiledCharsmap,
         addDummyPrefix: addDummyPrefix,
         removeExtraWhitespaces: removeExtraWhitespaces,
         escapeWhitespaces: escapeWhitespaces,

--- a/lib/src/sentencepiece/serialization/tokenizer_json.dart
+++ b/lib/src/sentencepiece/serialization/tokenizer_json.dart
@@ -61,8 +61,9 @@ extension SentencePieceTokenizerJson on SentencePieceTokenizer {
         'escape_whitespaces': normalizer.escapeWhitespaces,
         'normalizer_name': normalizer.normalizerName,
         if (normalizer.precompiledCharsmapBytes != null)
-          'precompiled_charsmap':
-              base64Encode(normalizer.precompiledCharsmapBytes!),
+          'precompiled_charsmap': base64Encode(
+            normalizer.precompiledCharsmapBytes!,
+          ),
       },
       'config': {
         'add_bos_token': config.addBosToken,
@@ -187,8 +188,7 @@ class TokenizerJsonLoader {
         normalizerData['remove_extra_whitespaces'] as bool? ?? true;
     final escapeWhitespaces =
         normalizerData['escape_whitespaces'] as bool? ?? true;
-    final normalizerName =
-        normalizerData['normalizer_name'] as String? ?? '';
+    final normalizerName = normalizerData['normalizer_name'] as String? ?? '';
     Uint8List? precompiledCharsmap;
     final charsmapB64 = normalizerData['precompiled_charsmap'] as String?;
     if (charsmapB64 != null) {

--- a/test/precompiled_charsmap_test.dart
+++ b/test/precompiled_charsmap_test.dart
@@ -27,9 +27,7 @@ void main() {
         final data = ByteData(4);
         data.setUint32(0, 1000, Endian.little);
         expect(
-          () => PrecompiledCharsmap.fromBytes(
-            data.buffer.asUint8List(),
-          ),
+          () => PrecompiledCharsmap.fromBytes(data.buffer.asUint8List()),
           throwsFormatException,
         );
       });
@@ -38,9 +36,7 @@ void main() {
         final blob = ByteData(4 + 7);
         blob.setUint32(0, 7, Endian.little);
         expect(
-          () => PrecompiledCharsmap.fromBytes(
-            blob.buffer.asUint8List(),
-          ),
+          () => PrecompiledCharsmap.fromBytes(blob.buffer.asUint8List()),
           throwsFormatException,
         );
       });
@@ -113,17 +109,11 @@ void main() {
           '\uFB01': 'fi', // ﬁ → fi
         });
         final charsmap = PrecompiledCharsmap.fromBytes(blob);
-        expect(
-          charsmap.normalize('\uFF21\uFB01\uFF22'),
-          equals('AfiB'),
-        );
+        expect(charsmap.normalize('\uFF21\uFB01\uFF22'), equals('AfiB'));
       });
 
       test('handles mixed mapped and unmapped characters', () {
-        final blob = _buildCharsmapBlob({
-          '\uFF21': 'A',
-          '\uFF22': 'B',
-        });
+        final blob = _buildCharsmapBlob({'\uFF21': 'A', '\uFF22': 'B'});
         final charsmap = PrecompiledCharsmap.fromBytes(blob);
         expect(
           charsmap.normalize('hello \uFF21 world \uFF22'),
@@ -142,37 +132,25 @@ void main() {
       test('all characters unmapped passes through unchanged', () {
         final blob = _buildCharsmapBlob({'X': 'x'});
         final charsmap = PrecompiledCharsmap.fromBytes(blob);
-        expect(
-          charsmap.normalize('hello world'),
-          equals('hello world'),
-        );
+        expect(charsmap.normalize('hello world'), equals('hello world'));
       });
 
       test('handles Korean text passthrough', () {
         final blob = _buildCharsmapBlob({'A': 'a'});
         final charsmap = PrecompiledCharsmap.fromBytes(blob);
-        expect(
-          charsmap.normalize('안녕하세요'),
-          equals('안녕하세요'),
-        );
+        expect(charsmap.normalize('안녕하세요'), equals('안녕하세요'));
       });
 
       test('handles CJK text passthrough', () {
         final blob = _buildCharsmapBlob({'A': 'a'});
         final charsmap = PrecompiledCharsmap.fromBytes(blob);
-        expect(
-          charsmap.normalize('你好世界'),
-          equals('你好世界'),
-        );
+        expect(charsmap.normalize('你好世界'), equals('你好世界'));
       });
 
       test('handles emoji passthrough', () {
         final blob = _buildCharsmapBlob({'A': 'a'});
         final charsmap = PrecompiledCharsmap.fromBytes(blob);
-        expect(
-          charsmap.normalize('Hello 👋 World'),
-          equals('Hello 👋 World'),
-        );
+        expect(charsmap.normalize('Hello 👋 World'), equals('Hello 👋 World'));
       });
     });
   });
@@ -241,8 +219,14 @@ void main() {
         escapeWhitespaces: true,
       );
       expect(normalizer.hasCharsmap, isFalse);
-      expect(normalizer.normalize('hello world'), equals('\u2581hello\u2581world'));
-      expect(normalizer.denormalize('\u2581hello\u2581world'), equals('hello world'));
+      expect(
+        normalizer.normalize('hello world'),
+        equals('\u2581hello\u2581world'),
+      );
+      expect(
+        normalizer.denormalize('\u2581hello\u2581world'),
+        equals('hello world'),
+      );
     });
   });
 }

--- a/test/precompiled_charsmap_test.dart
+++ b/test/precompiled_charsmap_test.dart
@@ -1,0 +1,423 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dart_sentencepiece_tokenizer/src/sentencepiece/model/model_proto.dart';
+import 'package:dart_sentencepiece_tokenizer/src/sentencepiece/normalizer/precompiled_charsmap.dart';
+import 'package:dart_sentencepiece_tokenizer/src/sentencepiece/normalizer/sp_normalizer.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PrecompiledCharsmap', () {
+    group('binary parsing', () {
+      test('parses a minimal valid blob', () {
+        final blob = _buildCharsmapBlob({'A': 'a'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(charsmap.normalize('A'), equals('a'));
+      });
+
+      test('throws on too-short data', () {
+        expect(
+          () => PrecompiledCharsmap.fromBytes(Uint8List.fromList([0, 0])),
+          throwsFormatException,
+        );
+      });
+
+      test('throws on trie size exceeding data', () {
+        // 4 bytes saying trie is 1000 bytes, but only 4 bytes total
+        final data = ByteData(4);
+        data.setUint32(0, 1000, Endian.little);
+        expect(
+          () => PrecompiledCharsmap.fromBytes(
+            data.buffer.asUint8List(),
+          ),
+          throwsFormatException,
+        );
+      });
+
+      test('throws on trie size not multiple of 4', () {
+        final blob = ByteData(4 + 7);
+        blob.setUint32(0, 7, Endian.little);
+        expect(
+          () => PrecompiledCharsmap.fromBytes(
+            blob.buffer.asUint8List(),
+          ),
+          throwsFormatException,
+        );
+      });
+    });
+
+    group('single byte mapping', () {
+      test('maps ASCII character', () {
+        final blob = _buildCharsmapBlob({'A': 'a'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(charsmap.normalize('A'), equals('a'));
+      });
+
+      test('passes through unmapped characters', () {
+        final blob = _buildCharsmapBlob({'A': 'a'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(charsmap.normalize('B'), equals('B'));
+      });
+
+      test('maps mixed text with passthrough', () {
+        final blob = _buildCharsmapBlob({'A': 'a', 'B': 'b'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(charsmap.normalize('ABCA'), equals('abCa'));
+      });
+    });
+
+    group('multi-byte UTF-8 mapping', () {
+      test('maps fullwidth ASCII to halfwidth', () {
+        // Ａ (U+FF21) → A
+        final blob = _buildCharsmapBlob({'\uFF21': 'A'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(charsmap.normalize('\uFF21'), equals('A'));
+      });
+
+      test('maps ligature to component characters', () {
+        // ﬁ (U+FB01) → fi
+        final blob = _buildCharsmapBlob({'\uFB01': 'fi'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(charsmap.normalize('\uFB01'), equals('fi'));
+      });
+
+      test('maps fullwidth digits', () {
+        // １ (U+FF11) → 1, ２ (U+FF12) → 2
+        final blob = _buildCharsmapBlob({'\uFF11': '1', '\uFF12': '2'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(charsmap.normalize('\uFF11\uFF12'), equals('12'));
+      });
+
+      test('maps halfwidth katakana to fullwidth', () {
+        // ｱ (U+FF71) → ア (U+30A2)
+        final blob = _buildCharsmapBlob({'\uFF71': '\u30A2'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(charsmap.normalize('\uFF71'), equals('\u30A2'));
+      });
+    });
+
+    group('deletion mapping', () {
+      test('deletes mapped characters (maps to empty string)', () {
+        // Map zero-width joiner to empty string (deletion)
+        final blob = _buildCharsmapBlob({'\u200D': ''});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(charsmap.normalize('a\u200Db'), equals('ab'));
+      });
+    });
+
+    group('multiple mappings', () {
+      test('applies multiple independent mappings', () {
+        final blob = _buildCharsmapBlob({
+          '\uFF21': 'A', // Ａ → A
+          '\uFF22': 'B', // Ｂ → B
+          '\uFB01': 'fi', // ﬁ → fi
+        });
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(
+          charsmap.normalize('\uFF21\uFB01\uFF22'),
+          equals('AfiB'),
+        );
+      });
+
+      test('handles mixed mapped and unmapped characters', () {
+        final blob = _buildCharsmapBlob({
+          '\uFF21': 'A',
+          '\uFF22': 'B',
+        });
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(
+          charsmap.normalize('hello \uFF21 world \uFF22'),
+          equals('hello A world B'),
+        );
+      });
+    });
+
+    group('edge cases', () {
+      test('empty input returns empty string', () {
+        final blob = _buildCharsmapBlob({'A': 'a'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(charsmap.normalize(''), equals(''));
+      });
+
+      test('all characters unmapped passes through unchanged', () {
+        final blob = _buildCharsmapBlob({'X': 'x'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(
+          charsmap.normalize('hello world'),
+          equals('hello world'),
+        );
+      });
+
+      test('handles Korean text passthrough', () {
+        final blob = _buildCharsmapBlob({'A': 'a'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(
+          charsmap.normalize('안녕하세요'),
+          equals('안녕하세요'),
+        );
+      });
+
+      test('handles CJK text passthrough', () {
+        final blob = _buildCharsmapBlob({'A': 'a'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(
+          charsmap.normalize('你好世界'),
+          equals('你好世界'),
+        );
+      });
+
+      test('handles emoji passthrough', () {
+        final blob = _buildCharsmapBlob({'A': 'a'});
+        final charsmap = PrecompiledCharsmap.fromBytes(blob);
+        expect(
+          charsmap.normalize('Hello 👋 World'),
+          equals('Hello 👋 World'),
+        );
+      });
+    });
+  });
+
+  group('SpNormalizer with charsmap', () {
+    test('applies charsmap before whitespace processing', () {
+      final blob = _buildCharsmapBlob({'\uFF21': 'A'});
+      final charsmap = PrecompiledCharsmap.fromBytes(blob);
+      final normalizer = SpNormalizer(
+        addDummyPrefix: true,
+        removeExtraWhitespaces: true,
+        escapeWhitespaces: true,
+        charsmap: charsmap,
+      );
+      // Input: Ａ → charsmap → A → dummy prefix → " A" → escape → "▁A"
+      expect(normalizer.normalize('\uFF21'), equals('\u2581A'));
+    });
+
+    test('fromSpec with precompiled charsmap', () {
+      final blob = _buildCharsmapBlob({'\uFF21': 'A'});
+      final spec = _createNormalizerSpec(
+        name: 'nmt_nfkc',
+        precompiledCharsmap: blob,
+      );
+      final normalizer = SpNormalizer.fromSpec(spec);
+      expect(normalizer.hasCharsmap, isTrue);
+      expect(normalizer.normalizerName, equals('nmt_nfkc'));
+      expect(normalizer.normalize('\uFF21'), equals('\u2581A'));
+    });
+
+    test('fromSpec without precompiled charsmap', () {
+      final spec = _createNormalizerSpec(name: 'identity');
+      final normalizer = SpNormalizer.fromSpec(spec);
+      expect(normalizer.hasCharsmap, isFalse);
+      expect(normalizer.normalizerName, equals('identity'));
+    });
+
+    test('denormalize is unaffected by charsmap', () {
+      final blob = _buildCharsmapBlob({'\uFF21': 'A'});
+      final charsmap = PrecompiledCharsmap.fromBytes(blob);
+      final normalizer = SpNormalizer(
+        addDummyPrefix: true,
+        escapeWhitespaces: true,
+        charsmap: charsmap,
+      );
+      expect(normalizer.denormalize('\u2581hello'), equals('hello'));
+    });
+
+    test('preserves precompiled charsmap bytes for serialization', () {
+      final blob = _buildCharsmapBlob({'\uFF21': 'A'});
+      final spec = _createNormalizerSpec(
+        name: 'nmt_nfkc',
+        precompiledCharsmap: blob,
+      );
+      final normalizer = SpNormalizer.fromSpec(spec);
+      expect(normalizer.precompiledCharsmapBytes, isNotNull);
+      expect(normalizer.precompiledCharsmapBytes, equals(blob));
+    });
+  });
+
+  group('backward compatibility', () {
+    test('SpNormalizer without charsmap behaves identically', () {
+      final normalizer = SpNormalizer(
+        addDummyPrefix: true,
+        removeExtraWhitespaces: true,
+        escapeWhitespaces: true,
+      );
+      expect(normalizer.hasCharsmap, isFalse);
+      expect(normalizer.normalize('hello world'), equals('\u2581hello\u2581world'));
+      expect(normalizer.denormalize('\u2581hello\u2581world'), equals('hello world'));
+    });
+  });
+}
+
+// ---- Test Helpers ----
+
+/// Build a precompiled charsmap binary blob from string-to-string mappings.
+Uint8List _buildCharsmapBlob(Map<String, String> mappings) {
+  // Convert string keys to UTF-8 byte sequences
+  final entries = <List<int>, String>{};
+  for (final entry in mappings.entries) {
+    entries[utf8.encode(entry.key)] = entry.value;
+  }
+
+  // Build normalized string table
+  final normalizedBytes = BytesBuilder();
+  final offsets = <String, int>{};
+  for (final entry in mappings.entries) {
+    offsets[entry.key] = normalizedBytes.length;
+    normalizedBytes.add(utf8.encode(entry.value));
+    normalizedBytes.addByte(0); // null terminator
+  }
+
+  // Build DARTS double-array trie
+  final trieEntries = <List<int>, int>{};
+  for (final entry in mappings.entries) {
+    trieEntries[utf8.encode(entry.key)] = offsets[entry.key]!;
+  }
+  final arrayData = _buildDartsArray(trieEntries);
+
+  // Assemble blob: [4-byte trie size][trie data][normalized strings]
+  final trieBlobSize = arrayData.length * 4;
+  final blob = BytesBuilder();
+
+  // Write trie blob size (little-endian uint32)
+  final sizeData = ByteData(4);
+  sizeData.setUint32(0, trieBlobSize, Endian.little);
+  blob.add(sizeData.buffer.asUint8List());
+
+  // Write trie array data (little-endian uint32 per unit)
+  for (final unit in arrayData) {
+    final unitData = ByteData(4);
+    unitData.setUint32(0, unit, Endian.little);
+    blob.add(unitData.buffer.asUint8List());
+  }
+
+  // Write normalized string pool
+  blob.add(normalizedBytes.toBytes());
+
+  return blob.toBytes();
+}
+
+/// Build a DARTS double-array from key-value entries.
+/// Keys are UTF-8 byte sequences, values are offsets into the string table.
+Uint32List _buildDartsArray(Map<List<int>, int> entries) {
+  // Build prefix trie
+  final root = _TrieNode();
+  for (final entry in entries.entries) {
+    var node = root;
+    for (final b in entry.key) {
+      node = node.children.putIfAbsent(b, () => _TrieNode());
+    }
+    node.value = entry.value;
+  }
+
+  // Convert to double-array
+  final array = List<int>.filled(1024, 0);
+  final used = List<bool>.filled(1024, false);
+  // Track used effective bases to prevent cross-node collisions.
+  // In DARTS, each node's effective base must be unique to avoid
+  // false positive matches during traversal.
+  final usedBases = <int>{};
+
+  void ensureSize(int size) {
+    while (array.length < size) {
+      array.add(0);
+      used.add(false);
+    }
+  }
+
+  void buildNode(_TrieNode node, int nodePos, int label) {
+    final childLabels = node.children.keys.toList()..sort();
+    final needLeaf = node.value != null;
+
+    // Find an effectiveBase that:
+    // 1. Is not already used as another node's effective base
+    // 2. Has no position conflicts for leaf and children
+    var effectiveBase = 1;
+    outer:
+    while (true) {
+      ensureSize(effectiveBase + 256);
+      // Must be a unique base
+      if (usedBases.contains(effectiveBase)) {
+        effectiveBase++;
+        continue;
+      }
+      // Check leaf position
+      if (needLeaf && used[effectiveBase]) {
+        effectiveBase++;
+        continue;
+      }
+      // Check child positions
+      for (final cl in childLabels) {
+        final pos = effectiveBase ^ cl;
+        ensureSize(pos + 1);
+        if (used[pos]) {
+          effectiveBase++;
+          continue outer;
+        }
+      }
+      break;
+    }
+    usedBases.add(effectiveBase);
+
+    // offset = nodePos ^ effectiveBase (so that nodePos ^ offset = effectiveBase)
+    final offset = nodePos ^ effectiveBase;
+
+    // Encode unit: [offset bits 10-31][bit 9: offset mode][bit 8: has_leaf][bits 0-7: label]
+    var unit = (offset << 10) | (label & 0xFF);
+    if (needLeaf) unit |= 1 << 8;
+
+    ensureSize(nodePos + 1);
+    array[nodePos] = unit;
+    used[nodePos] = true;
+
+    // Place leaf value unit
+    if (needLeaf) {
+      ensureSize(effectiveBase + 1);
+      array[effectiveBase] = 0x80000000 | node.value!;
+      used[effectiveBase] = true;
+    }
+
+    // Reserve child positions before recursing
+    for (final cl in childLabels) {
+      final pos = effectiveBase ^ cl;
+      ensureSize(pos + 1);
+      used[pos] = true;
+    }
+
+    // Build children
+    for (final cl in childLabels) {
+      final childPos = effectiveBase ^ cl;
+      buildNode(node.children[cl]!, childPos, cl);
+    }
+  }
+
+  buildNode(root, 0, 0);
+
+  // Trim trailing unused entries
+  var lastUsed = array.length - 1;
+  while (lastUsed > 0 && !used[lastUsed]) {
+    lastUsed--;
+  }
+
+  return Uint32List.fromList(array.sublist(0, lastUsed + 1));
+}
+
+class _TrieNode {
+  final children = <int, _TrieNode>{};
+  int? value;
+}
+
+/// Create a NormalizerSpec for testing.
+NormalizerSpec _createNormalizerSpec({
+  String name = '',
+  Uint8List? precompiledCharsmap,
+  bool addDummyPrefix = true,
+  bool removeExtraWhitespaces = true,
+  bool escapeWhitespaces = true,
+}) {
+  return NormalizerSpec(
+    name: name,
+    precompiledCharsmap: precompiledCharsmap,
+    addDummyPrefix: addDummyPrefix,
+    removeExtraWhitespaces: removeExtraWhitespaces,
+    escapeWhitespaces: escapeWhitespaces,
+  );
+}

--- a/test/sentencepiece_test.dart
+++ b/test/sentencepiece_test.dart
@@ -62,7 +62,7 @@ void main() {
 
   group('SpNormalizer', () {
     test('normalize with default settings', () {
-      const normalizer = SpNormalizer();
+      final normalizer = SpNormalizer();
 
       // Should add dummy prefix and escape whitespaces
       final result = normalizer.normalize('hello world');
@@ -72,7 +72,7 @@ void main() {
     });
 
     test('normalize without dummy prefix', () {
-      const normalizer = SpNormalizer(addDummyPrefix: false);
+      final normalizer = SpNormalizer(addDummyPrefix: false);
 
       final result = normalizer.normalize('hello world');
 
@@ -80,7 +80,7 @@ void main() {
     });
 
     test('remove extra whitespaces', () {
-      const normalizer = SpNormalizer(removeExtraWhitespaces: true);
+      final normalizer = SpNormalizer(removeExtraWhitespaces: true);
 
       final result = normalizer.normalize('hello   world');
 
@@ -89,7 +89,7 @@ void main() {
     });
 
     test('preserve whitespaces when not escaping', () {
-      const normalizer = SpNormalizer(escapeWhitespaces: false);
+      final normalizer = SpNormalizer(escapeWhitespaces: false);
 
       final result = normalizer.normalize('hello');
 
@@ -97,7 +97,7 @@ void main() {
     });
 
     test('denormalize reverses normalize', () {
-      const normalizer = SpNormalizer();
+      final normalizer = SpNormalizer();
 
       final normalized = normalizer.normalize('hello world');
       final denormalized = normalizer.denormalize(normalized);
@@ -106,7 +106,7 @@ void main() {
     });
 
     test('empty string', () {
-      const normalizer = SpNormalizer();
+      final normalizer = SpNormalizer();
 
       expect(normalizer.normalize(''), equals(''));
       expect(normalizer.denormalize(''), equals(''));


### PR DESCRIPTION
## Summary

- Implement SentencePiece's `precompiled_charsmap` normalization to resolve token mismatches in non-Latin scripts (Korean, Japanese, etc.)
- Add DARTS (Double-ARray Trie System) decoder that parses the binary blob embedded in `.model` files and applies leftmost-longest string-to-string replacement before whitespace processing, matching the C++ SentencePiece behavior
- Integrate charsmap into `SpNormalizer` pipeline, `_SerializableModelData` (Isolate support), and JSON serialization (base64 round-trip)

### New files
- `lib/src/sentencepiece/normalizer/precompiled_charsmap.dart` — DARTS trie decoder
- `test/precompiled_charsmap_test.dart` — 25 new tests

### Modified files
- `sp_normalizer.dart` — charsmap applied before whitespace processing
- `sentencepiece_tokenizer.dart` — `_SerializableModelData` carries charsmap for Isolate support
- `tokenizer_json.dart` — base64 charsmap serialization/deserialization
- `sentencepiece_test.dart` — adapted to non-const `SpNormalizer`

## Test plan

- [x] `dart analyze` — 0 issues
- [x] All 327 tests pass (302 existing + 25 new)
- [x] New tests cover: binary parsing, single/multi-byte mappings, deletion, passthrough, Korean/CJK/emoji, SpNormalizer integration, backward compatibility

Closes #12

https://claude.ai/code/session_01GWiEgMdQpZjCQyqujW7ghX