### PR TITLE
feat: add precompiled_charsmap support in normalizer

### DIFF
--- a/lib/src/sentencepiece/normalizer/precompiled_charsmap.dart
+++ b/lib/src/sentencepiece/normalizer/precompiled_charsmap.dart
@@ -49,12 +49,10 @@ class PrecompiledCharsMap {
   }
 
   /// Returns the base value for node at [index]. Caller must ensure validity.
-  int _base(int index) =>
-      _trieData.getInt32(index * 8, Endian.little);
+  int _base(int index) => _trieData.getInt32(index * 8, Endian.little);
 
   /// Returns the check value for node at [index]. Caller must ensure validity.
-  int _check(int index) =>
-      _trieData.getInt32(index * 8 + 4, Endian.little);
+  int _check(int index) => _trieData.getInt32(index * 8 + 4, Endian.little);
 
   bool _isValidNode(int index) => index >= 0 && index < _trieNodeCount;
 

--- a/lib/src/sentencepiece/normalizer/precompiled_charsmap.dart
+++ b/lib/src/sentencepiece/normalizer/precompiled_charsmap.dart
@@ -25,10 +25,11 @@ class PrecompiledCharsMap {
     this.rawBytes,
   );
 
-  /// Parses a precompiled_charsmap binary blob.
   factory PrecompiledCharsMap(Uint8List data) {
     if (data.length < 4) {
-      throw ArgumentError('precompiled_charsmap data too short: ${data.length}');
+      throw ArgumentError(
+        'precompiled_charsmap data too short: ${data.length}',
+      );
     }
 
     final byteData = ByteData.sublistView(data);
@@ -40,41 +41,33 @@ class PrecompiledCharsMap {
       );
     }
 
-    // Each DARTS node is a pair of int32 values (base, check) = 8 bytes.
     final trieData = ByteData.sublistView(data, 4, 4 + trieBlobSize);
     final trieNodeCount = trieBlobSize ~/ 8;
-
-    // The remaining bytes are the normalized string pool.
     final normalizedPool = Uint8List.sublistView(data, 4 + trieBlobSize);
 
     return PrecompiledCharsMap._(trieData, trieNodeCount, normalizedPool, data);
   }
 
-  /// Returns the base value for a DARTS trie node at [index].
-  int _base(int index) {
-    final offset = index * 8;
-    if (offset < 0 || offset + 4 > _trieData.lengthInBytes) return 0;
-    return _trieData.getInt32(offset, Endian.little);
-  }
+  /// Returns the base value for node at [index]. Caller must ensure validity.
+  int _base(int index) =>
+      _trieData.getInt32(index * 8, Endian.little);
 
-  /// Returns the check value for a DARTS trie node at [index].
-  int _check(int index) {
-    final offset = index * 8 + 4;
-    if (offset < 0 || offset + 4 > _trieData.lengthInBytes) return -1;
-    return _trieData.getInt32(offset, Endian.little);
-  }
+  /// Returns the check value for node at [index]. Caller must ensure validity.
+  int _check(int index) =>
+      _trieData.getInt32(index * 8 + 4, Endian.little);
 
-  /// Whether a node index is within the trie bounds.
   bool _isValidNode(int index) => index >= 0 && index < _trieNodeCount;
 
-  /// Reads a null-terminated UTF-8 string from the normalized pool at [offset].
-  String _readPoolString(int offset) {
-    if (offset < 0 || offset >= _normalizedPool.length) return '';
+  /// Returns a view of the null-terminated UTF-8 bytes at [offset] in the pool.
+  Uint8List _readPoolBytes(int offset) {
+    if (offset < 0 || offset >= _normalizedPool.length) {
+      return Uint8List(0);
+    }
     var end = offset;
     while (end < _normalizedPool.length && _normalizedPool[end] != 0) {
       end++;
     }
-    return utf8.decode(_normalizedPool.sublist(offset, end));
+    return Uint8List.sublistView(_normalizedPool, offset, end);
   }
 
   /// Finds the longest matching prefix in the trie starting at [start] in
@@ -87,24 +80,18 @@ class PrecompiledCharsMap {
     var lastMatchLength = 0;
 
     for (var i = start; i < bytes.length; i++) {
-      final byte = bytes[i];
-
-      // DARTS transition: next = base[node] + byte + 1
-      final next = _base(node) + byte + 1;
+      final next = _base(node) + bytes[i] + 1;
       if (!_isValidNode(next) || _check(next) != node) break;
 
       node = next;
 
-      // Check for terminal: follow the "end of key" transition (value 0).
-      // In DARTS, terminal node = base[node] + 0 + 1 = base[node] + 1
-      // But the standard convention uses a separate check:
-      // termNode = base[node]; if base[termNode] is negative, it's a leaf.
-      // Actually in SentencePiece's DARTS: the terminal check uses offset 0.
-      final termNode = _base(node);
-      if (_isValidNode(termNode) && _check(termNode) == node) {
-        final termBase = _base(termNode);
+      // Terminal check: in SentencePiece's DARTS, base[node] points to the
+      // terminal node. A negative base at the terminal is a leaf whose
+      // absolute value encodes the string pool offset.
+      final nodeBase = _base(node);
+      if (_isValidNode(nodeBase) && _check(nodeBase) == node) {
+        final termBase = _base(nodeBase);
         if (termBase < 0) {
-          // Leaf node: |base| is offset into the normalized string pool.
           lastPoolOffset = -termBase - 1;
           lastMatchLength = i - start + 1;
         }
@@ -117,21 +104,16 @@ class PrecompiledCharsMap {
     return null;
   }
 
-  /// Returns the number of bytes for a UTF-8 character starting with
-  /// the given leading [byte].
+  /// Returns the number of bytes for a UTF-8 character from its leading byte.
   static int _utf8CharLength(int byte) {
     if (byte < 0x80) return 1;
-    if (byte < 0xC0) return 1; // continuation byte (shouldn't be leading)
+    if (byte < 0xC0) return 1; // continuation byte as leading byte
     if (byte < 0xE0) return 2;
     if (byte < 0xF0) return 3;
     return 4;
   }
 
   /// Applies character mapping normalization to [input].
-  ///
-  /// For each position in the UTF-8 encoded input, attempts to find the
-  /// longest match in the trie. Matched sequences are replaced with the
-  /// corresponding string from the pool. Unmatched characters pass through.
   String normalize(String input) {
     if (input.isEmpty) return input;
 
@@ -143,15 +125,20 @@ class PrecompiledCharsMap {
       final match = _findLongestMatch(inputBytes, i);
       if (match != null) {
         final (poolOffset, matchLength) = match;
-        final replacement = _readPoolString(poolOffset);
-        result.add(utf8.encode(replacement));
+        // Add pool bytes directly — avoids decode/re-encode round-trip.
+        result.add(_readPoolBytes(poolOffset));
         i += matchLength;
       } else {
         // No match: copy the current UTF-8 character as-is.
         final charLen = _utf8CharLength(inputBytes[i]);
-        final end = (i + charLen).clamp(0, inputBytes.length);
-        result.add(inputBytes.sublist(i, end));
-        i = end;
+        if (charLen == 1) {
+          result.addByte(inputBytes[i]);
+          i += 1;
+        } else {
+          final end = (i + charLen).clamp(0, inputBytes.length);
+          result.add(Uint8List.sublistView(inputBytes, i, end));
+          i = end;
+        }
       }
     }
 

--- a/lib/src/sentencepiece/normalizer/precompiled_charsmap.dart
+++ b/lib/src/sentencepiece/normalizer/precompiled_charsmap.dart
@@ -1,0 +1,160 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Decodes and applies precompiled character mappings from SentencePiece models.
+///
+/// The binary format consists of:
+/// 1. 4 bytes (LE uint32): trie blob size
+/// 2. [trieBlobSize] bytes: Double-Array Trie (DARTS format)
+/// 3. Remaining bytes: null-terminated UTF-8 replacement strings
+///
+/// The DARTS trie operates on raw UTF-8 bytes and maps character sequences
+/// to replacement strings for normalization (typically NFKC).
+class PrecompiledCharsMap {
+  final ByteData _trieData;
+  final int _trieNodeCount;
+  final Uint8List _normalizedPool;
+
+  /// The raw binary data, retained for serialization across isolates.
+  final Uint8List rawBytes;
+
+  PrecompiledCharsMap._(
+    this._trieData,
+    this._trieNodeCount,
+    this._normalizedPool,
+    this.rawBytes,
+  );
+
+  /// Parses a precompiled_charsmap binary blob.
+  factory PrecompiledCharsMap(Uint8List data) {
+    if (data.length < 4) {
+      throw ArgumentError('precompiled_charsmap data too short: ${data.length}');
+    }
+
+    final byteData = ByteData.sublistView(data);
+    final trieBlobSize = byteData.getUint32(0, Endian.little);
+
+    if (4 + trieBlobSize > data.length) {
+      throw ArgumentError(
+        'Invalid trie blob size: $trieBlobSize (data length: ${data.length})',
+      );
+    }
+
+    // Each DARTS node is a pair of int32 values (base, check) = 8 bytes.
+    final trieData = ByteData.sublistView(data, 4, 4 + trieBlobSize);
+    final trieNodeCount = trieBlobSize ~/ 8;
+
+    // The remaining bytes are the normalized string pool.
+    final normalizedPool = Uint8List.sublistView(data, 4 + trieBlobSize);
+
+    return PrecompiledCharsMap._(trieData, trieNodeCount, normalizedPool, data);
+  }
+
+  /// Returns the base value for a DARTS trie node at [index].
+  int _base(int index) {
+    final offset = index * 8;
+    if (offset < 0 || offset + 4 > _trieData.lengthInBytes) return 0;
+    return _trieData.getInt32(offset, Endian.little);
+  }
+
+  /// Returns the check value for a DARTS trie node at [index].
+  int _check(int index) {
+    final offset = index * 8 + 4;
+    if (offset < 0 || offset + 4 > _trieData.lengthInBytes) return -1;
+    return _trieData.getInt32(offset, Endian.little);
+  }
+
+  /// Whether a node index is within the trie bounds.
+  bool _isValidNode(int index) => index >= 0 && index < _trieNodeCount;
+
+  /// Reads a null-terminated UTF-8 string from the normalized pool at [offset].
+  String _readPoolString(int offset) {
+    if (offset < 0 || offset >= _normalizedPool.length) return '';
+    var end = offset;
+    while (end < _normalizedPool.length && _normalizedPool[end] != 0) {
+      end++;
+    }
+    return utf8.decode(_normalizedPool.sublist(offset, end));
+  }
+
+  /// Finds the longest matching prefix in the trie starting at [start] in
+  /// the given UTF-8 [bytes].
+  ///
+  /// Returns `(poolOffset, matchLength)` or `null` if no match.
+  (int, int)? _findLongestMatch(Uint8List bytes, int start) {
+    var node = 0;
+    int? lastPoolOffset;
+    var lastMatchLength = 0;
+
+    for (var i = start; i < bytes.length; i++) {
+      final byte = bytes[i];
+
+      // DARTS transition: next = base[node] + byte + 1
+      final next = _base(node) + byte + 1;
+      if (!_isValidNode(next) || _check(next) != node) break;
+
+      node = next;
+
+      // Check for terminal: follow the "end of key" transition (value 0).
+      // In DARTS, terminal node = base[node] + 0 + 1 = base[node] + 1
+      // But the standard convention uses a separate check:
+      // termNode = base[node]; if base[termNode] is negative, it's a leaf.
+      // Actually in SentencePiece's DARTS: the terminal check uses offset 0.
+      final termNode = _base(node);
+      if (_isValidNode(termNode) && _check(termNode) == node) {
+        final termBase = _base(termNode);
+        if (termBase < 0) {
+          // Leaf node: |base| is offset into the normalized string pool.
+          lastPoolOffset = -termBase - 1;
+          lastMatchLength = i - start + 1;
+        }
+      }
+    }
+
+    if (lastPoolOffset != null) {
+      return (lastPoolOffset, lastMatchLength);
+    }
+    return null;
+  }
+
+  /// Returns the number of bytes for a UTF-8 character starting with
+  /// the given leading [byte].
+  static int _utf8CharLength(int byte) {
+    if (byte < 0x80) return 1;
+    if (byte < 0xC0) return 1; // continuation byte (shouldn't be leading)
+    if (byte < 0xE0) return 2;
+    if (byte < 0xF0) return 3;
+    return 4;
+  }
+
+  /// Applies character mapping normalization to [input].
+  ///
+  /// For each position in the UTF-8 encoded input, attempts to find the
+  /// longest match in the trie. Matched sequences are replaced with the
+  /// corresponding string from the pool. Unmatched characters pass through.
+  String normalize(String input) {
+    if (input.isEmpty) return input;
+
+    final inputBytes = utf8.encode(input);
+    final result = BytesBuilder(copy: false);
+    var i = 0;
+
+    while (i < inputBytes.length) {
+      final match = _findLongestMatch(inputBytes, i);
+      if (match != null) {
+        final (poolOffset, matchLength) = match;
+        final replacement = _readPoolString(poolOffset);
+        result.add(utf8.encode(replacement));
+        i += matchLength;
+      } else {
+        // No match: copy the current UTF-8 character as-is.
+        final charLen = _utf8CharLength(inputBytes[i]);
+        final end = (i + charLen).clamp(0, inputBytes.length);
+        result.add(inputBytes.sublist(i, end));
+        i = end;
+      }
+    }
+
+    return utf8.decode(result.toBytes());
+  }
+}

--- a/lib/src/sentencepiece/normalizer/sp_normalizer.dart
+++ b/lib/src/sentencepiece/normalizer/sp_normalizer.dart
@@ -1,4 +1,7 @@
+import 'dart:typed_data';
+
 import '../model/model_proto.dart';
+import 'precompiled_charsmap.dart';
 
 /// SentencePiece whitespace replacement character.
 const String kSpaceSymbol = '\u2581'; // ▁ (Lower One Eighth Block)
@@ -7,25 +10,41 @@ class SpNormalizer {
   final bool addDummyPrefix;
   final bool removeExtraWhitespaces;
   final bool escapeWhitespaces;
+  final PrecompiledCharsMap? _charsmap;
 
-  const SpNormalizer({
+  SpNormalizer({
     this.addDummyPrefix = true,
     this.removeExtraWhitespaces = true,
     this.escapeWhitespaces = true,
-  });
+    PrecompiledCharsMap? precompiledCharsmap,
+  }) : _charsmap = precompiledCharsmap;
 
   factory SpNormalizer.fromSpec(NormalizerSpec spec) {
+    PrecompiledCharsMap? charsmap;
+    if (spec.precompiledCharsmap != null &&
+        spec.precompiledCharsmap!.isNotEmpty) {
+      charsmap = PrecompiledCharsMap(spec.precompiledCharsmap!);
+    }
     return SpNormalizer(
       addDummyPrefix: spec.addDummyPrefix,
       removeExtraWhitespaces: spec.removeExtraWhitespaces,
       escapeWhitespaces: spec.escapeWhitespaces,
+      precompiledCharsmap: charsmap,
     );
   }
+
+  /// Returns the raw precompiled charsmap bytes for serialization.
+  Uint8List? get precompiledCharsmapBytes => _charsmap?.rawBytes;
 
   String normalize(String text) {
     if (text.isEmpty) return text;
 
     var result = text;
+
+    // Step 0: Apply precompiled charsmap normalization
+    if (_charsmap != null) {
+      result = _charsmap.normalize(result);
+    }
 
     // Step 1: Remove extra whitespaces
     if (removeExtraWhitespaces) {

--- a/lib/src/sentencepiece/sentencepiece_tokenizer.dart
+++ b/lib/src/sentencepiece/sentencepiece_tokenizer.dart
@@ -928,8 +928,9 @@ class _SerializableModelData {
   final bool addDummyPrefix;
   final bool removeExtraWhitespaces;
   final bool escapeWhitespaces;
+  final Uint8List? precompiledCharsmap;
 
-  const _SerializableModelData({
+  _SerializableModelData({
     required this.pieces,
     required this.scores,
     required this.types,
@@ -946,6 +947,7 @@ class _SerializableModelData {
     required this.addDummyPrefix,
     required this.removeExtraWhitespaces,
     required this.escapeWhitespaces,
+    this.precompiledCharsmap,
   });
 
   factory _SerializableModelData.fromTokenizer(
@@ -971,6 +973,7 @@ class _SerializableModelData {
       addDummyPrefix: tokenizer._normalizer.addDummyPrefix,
       removeExtraWhitespaces: tokenizer._normalizer.removeExtraWhitespaces,
       escapeWhitespaces: tokenizer._normalizer.escapeWhitespaces,
+      precompiledCharsmap: tokenizer._normalizer.precompiledCharsmapBytes,
     );
   }
 
@@ -1007,6 +1010,7 @@ class _SerializableModelData {
         addDummyPrefix: addDummyPrefix,
         removeExtraWhitespaces: removeExtraWhitespaces,
         escapeWhitespaces: escapeWhitespaces,
+        precompiledCharsmap: precompiledCharsmap,
       ),
     );
 

--- a/test/precompiled_charsmap_test.dart
+++ b/test/precompiled_charsmap_test.dart
@@ -1,0 +1,295 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dart_sentencepiece_tokenizer/src/sentencepiece/model/model_proto.dart';
+import 'package:dart_sentencepiece_tokenizer/src/sentencepiece/normalizer/precompiled_charsmap.dart';
+import 'package:dart_sentencepiece_tokenizer/src/sentencepiece/normalizer/sp_normalizer.dart';
+import 'package:test/test.dart';
+
+/// Builds a synthetic precompiled_charsmap binary blob for testing.
+///
+/// The DARTS Double-Array Trie format:
+/// - Each node is 8 bytes: int32 base (LE) + int32 check (LE)
+/// - Root node is at index 0
+/// - Transition: next = base[node] + byte + 1, valid if check[next] == node
+/// - Terminal: termNode = base[node], valid if check[termNode] == node
+///   and base[termNode] < 0 => poolOffset = -(base[termNode]) - 1
+class DartsTrieBuilder {
+  // (base, check) pairs indexed by node ID
+  final List<int> _base = [];
+  final List<int> _check = [];
+  final BytesBuilder _pool = BytesBuilder();
+  int _nodeCount = 0;
+
+  DartsTrieBuilder() {
+    // Allocate root node (index 0)
+    _allocateNode();
+    _base[0] = 1; // root base; transitions start at base + byte + 1
+    _check[0] = -1; // root has no parent
+  }
+
+  int _allocateNode() {
+    final id = _nodeCount++;
+    _base.add(0);
+    _check.add(-1);
+    return id;
+  }
+
+  /// Ensures node at [index] exists, allocating up to that index if needed.
+  void _ensureNode(int index) {
+    while (_nodeCount <= index) {
+      _allocateNode();
+    }
+  }
+
+  /// Adds a mapping: [utf8Key] bytes -> [replacement] string.
+  void addMapping(List<int> utf8Key, String replacement) {
+    var node = 0;
+
+    // Walk or create nodes for each byte
+    for (final byte in utf8Key) {
+      final next = _base[node] + byte + 1;
+      _ensureNode(next);
+
+      if (_check[next] == -1) {
+        // Unclaimed node, assign it
+        _check[next] = node;
+        // Set a default base for the new node that won't collide
+        // Use a high offset to avoid collisions with other transitions
+        _base[next] = _nodeCount + 256;
+        _ensureNode(_base[next] + 256); // ensure space
+      } else if (_check[next] != node) {
+        throw StateError(
+          'DARTS collision at node $next: check=${_check[next]} != $node. '
+          'This simple builder cannot resolve collisions.',
+        );
+      }
+
+      node = next;
+    }
+
+    // Create terminal node: termNode = base[node], check[termNode] == node
+    final termNode = _base[node];
+    _ensureNode(termNode);
+    _check[termNode] = node;
+
+    // Leaf: base[termNode] = -(poolOffset) - 1
+    final poolOffset = _pool.length;
+    _pool.add(utf8.encode(replacement));
+    _pool.addByte(0); // null terminator
+    _base[termNode] = -poolOffset - 1;
+  }
+
+  /// Builds the final binary blob.
+  Uint8List build() {
+    // Trie blob: nodeCount * 8 bytes
+    final trieBlobSize = _nodeCount * 8;
+    final trieBlob = ByteData(trieBlobSize);
+    for (var i = 0; i < _nodeCount; i++) {
+      trieBlob.setInt32(i * 8, _base[i], Endian.little);
+      trieBlob.setInt32(i * 8 + 4, _check[i], Endian.little);
+    }
+
+    final poolBytes = _pool.toBytes();
+
+    // Final blob: 4 bytes (trieBlobSize) + trieBlob + poolBytes
+    final result = ByteData(4 + trieBlobSize + poolBytes.length);
+    result.setUint32(0, trieBlobSize, Endian.little);
+
+    final resultBytes = result.buffer.asUint8List();
+    resultBytes.setRange(4, 4 + trieBlobSize, trieBlob.buffer.asUint8List());
+    resultBytes.setRange(
+      4 + trieBlobSize,
+      4 + trieBlobSize + poolBytes.length,
+      poolBytes,
+    );
+
+    return resultBytes;
+  }
+}
+
+void main() {
+  group('PrecompiledCharsMap', () {
+    group('parsing', () {
+      test('throws on data too short', () {
+        expect(
+          () => PrecompiledCharsMap(Uint8List.fromList([1, 2])),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws on invalid trie blob size', () {
+        // Claim 1000 bytes of trie but only provide 8 bytes total
+        final data = ByteData(8);
+        data.setUint32(0, 1000, Endian.little);
+        expect(
+          () => PrecompiledCharsMap(data.buffer.asUint8List()),
+          throwsArgumentError,
+        );
+      });
+
+      test('parses valid blob without error', () {
+        final builder = DartsTrieBuilder();
+        builder.addMapping([0x41], 'a'); // 'A' -> 'a'
+        final data = builder.build();
+        expect(() => PrecompiledCharsMap(data), returnsNormally);
+      });
+    });
+
+    group('normalize', () {
+      test('empty input returns empty string', () {
+        final builder = DartsTrieBuilder();
+        builder.addMapping([0x41], 'a');
+        final charsmap = PrecompiledCharsMap(builder.build());
+
+        expect(charsmap.normalize(''), equals(''));
+      });
+
+      test('single ASCII byte mapping', () {
+        final builder = DartsTrieBuilder();
+        builder.addMapping([0x41], 'x'); // 'A' (0x41) -> 'x'
+        final charsmap = PrecompiledCharsMap(builder.build());
+
+        expect(charsmap.normalize('A'), equals('x'));
+      });
+
+      test('unmapped characters pass through', () {
+        final builder = DartsTrieBuilder();
+        builder.addMapping([0x41], 'x'); // Only 'A' is mapped
+        final charsmap = PrecompiledCharsMap(builder.build());
+
+        expect(charsmap.normalize('B'), equals('B'));
+        expect(charsmap.normalize('hello'), equals('hello'));
+      });
+
+      test('mixed mapped and unmapped characters', () {
+        final builder = DartsTrieBuilder();
+        builder.addMapping([0x41], 'x'); // 'A' -> 'x'
+        final charsmap = PrecompiledCharsMap(builder.build());
+
+        expect(charsmap.normalize('hAllo'), equals('hxllo'));
+      });
+
+      test('multiple occurrences of mapped character', () {
+        final builder = DartsTrieBuilder();
+        builder.addMapping([0x41], 'x'); // 'A' -> 'x'
+        final charsmap = PrecompiledCharsMap(builder.build());
+
+        expect(charsmap.normalize('ABA'), equals('xBx'));
+      });
+
+      test('mapping to multi-character replacement', () {
+        final builder = DartsTrieBuilder();
+        builder.addMapping([0x41], 'abc'); // 'A' -> 'abc'
+        final charsmap = PrecompiledCharsMap(builder.build());
+
+        expect(charsmap.normalize('A'), equals('abc'));
+      });
+
+      test('mapping to empty replacement', () {
+        final builder = DartsTrieBuilder();
+        builder.addMapping([0x41], ''); // 'A' -> '' (delete)
+        final charsmap = PrecompiledCharsMap(builder.build());
+
+        expect(charsmap.normalize('ABA'), equals('B'));
+      });
+
+      test('multi-byte UTF-8 source unmapped passes through', () {
+        final builder = DartsTrieBuilder();
+        builder.addMapping([0x41], 'x'); // Only ASCII 'A' mapped
+        final charsmap = PrecompiledCharsMap(builder.build());
+
+        // Korean character '한' is 3 bytes in UTF-8
+        expect(charsmap.normalize('한'), equals('한'));
+        // 4-byte emoji
+        expect(charsmap.normalize('😀'), equals('😀'));
+      });
+
+      test('multi-byte UTF-8 source mapped', () {
+        final builder = DartsTrieBuilder();
+        // Map 'é' (U+00E9) = UTF-8: [0xC3, 0xA9] -> 'e'
+        builder.addMapping([0xC3, 0xA9], 'e');
+        final charsmap = PrecompiledCharsMap(builder.build());
+
+        expect(charsmap.normalize('café'), equals('cafe'));
+      });
+    });
+
+    group('rawBytes', () {
+      test('preserves original bytes for serialization', () {
+        final builder = DartsTrieBuilder();
+        builder.addMapping([0x41], 'x');
+        final data = builder.build();
+        final charsmap = PrecompiledCharsMap(data);
+
+        expect(charsmap.rawBytes, equals(data));
+      });
+    });
+  });
+
+  group('SpNormalizer with precompiledCharsmap', () {
+    test('no charsmap behaves identically to before', () {
+      final normalizer = SpNormalizer();
+      final result = normalizer.normalize('hello world');
+
+      expect(result, contains(kSpaceSymbol));
+      expect(result, startsWith(kSpaceSymbol));
+    });
+
+    test('charsmap applied before whitespace normalization', () {
+      final builder = DartsTrieBuilder();
+      builder.addMapping([0x41], ' '); // 'A' -> space
+      final charsmap = PrecompiledCharsMap(builder.build());
+
+      final normalizer = SpNormalizer(precompiledCharsmap: charsmap);
+      final result = normalizer.normalize('hAllo');
+
+      // 'A' -> ' ', then whitespace collapsing/escaping runs
+      // Result: normalize("h llo") -> "▁h▁llo"
+      expect(result, equals('${kSpaceSymbol}h${kSpaceSymbol}llo'));
+    });
+
+    test('fromSpec creates normalizer with charsmap', () {
+      final builder = DartsTrieBuilder();
+      builder.addMapping([0x41], 'x');
+      final data = builder.build();
+
+      final spec = NormalizerSpec(
+        precompiledCharsmap: data,
+        addDummyPrefix: false,
+        escapeWhitespaces: false,
+        removeExtraWhitespaces: false,
+      );
+
+      final normalizer = SpNormalizer.fromSpec(spec);
+      expect(normalizer.normalize('A'), equals('x'));
+    });
+
+    test('fromSpec without charsmap works normally', () {
+      const spec = NormalizerSpec(
+        addDummyPrefix: false,
+        escapeWhitespaces: false,
+        removeExtraWhitespaces: false,
+      );
+
+      final normalizer = SpNormalizer.fromSpec(spec);
+      expect(normalizer.normalize('hello'), equals('hello'));
+    });
+
+    test('precompiledCharsmapBytes returns raw bytes', () {
+      final builder = DartsTrieBuilder();
+      builder.addMapping([0x41], 'x');
+      final data = builder.build();
+
+      final spec = NormalizerSpec(precompiledCharsmap: data);
+      final normalizer = SpNormalizer.fromSpec(spec);
+
+      expect(normalizer.precompiledCharsmapBytes, equals(data));
+    });
+
+    test('precompiledCharsmapBytes returns null when no charsmap', () {
+      final normalizer = SpNormalizer();
+      expect(normalizer.precompiledCharsmapBytes, isNull);
+    });
+  });
+}

--- a/test/sentencepiece_test.dart
+++ b/test/sentencepiece_test.dart
@@ -62,7 +62,7 @@ void main() {
 
   group('SpNormalizer', () {
     test('normalize with default settings', () {
-      const normalizer = SpNormalizer();
+      final normalizer = SpNormalizer();
 
       // Should add dummy prefix and escape whitespaces
       final result = normalizer.normalize('hello world');
@@ -72,7 +72,7 @@ void main() {
     });
 
     test('normalize without dummy prefix', () {
-      const normalizer = SpNormalizer(addDummyPrefix: false);
+      final normalizer = SpNormalizer(addDummyPrefix: false);
 
       final result = normalizer.normalize('hello world');
 
@@ -80,7 +80,7 @@ void main() {
     });
 
     test('remove extra whitespaces', () {
-      const normalizer = SpNormalizer(removeExtraWhitespaces: true);
+      final normalizer = SpNormalizer(removeExtraWhitespaces: true);
 
       final result = normalizer.normalize('hello   world');
 
@@ -89,7 +89,7 @@ void main() {
     });
 
     test('preserve whitespaces when not escaping', () {
-      const normalizer = SpNormalizer(escapeWhitespaces: false);
+      final normalizer = SpNormalizer(escapeWhitespaces: false);
 
       final result = normalizer.normalize('hello');
 
@@ -97,7 +97,7 @@ void main() {
     });
 
     test('denormalize reverses normalize', () {
-      const normalizer = SpNormalizer();
+      final normalizer = SpNormalizer();
 
       final normalized = normalizer.normalize('hello world');
       final denormalized = normalizer.denormalize(normalized);
@@ -106,7 +106,7 @@ void main() {
     });
 
     test('empty string', () {
-      const normalizer = SpNormalizer();
+      final normalizer = SpNormalizer();
 
       expect(normalizer.normalize(''), equals(''));
       expect(normalizer.denormalize(''), equals(''));


### PR DESCRIPTION
## Summary

- Add `PrecompiledCharsMap` class that parses DARTS Double-Array Trie binary blobs from `normalizer_spec.precompiled_charsmap` and applies character mapping normalization
- Integrate charsmap as Step 0 in `SpNormalizer.normalize()` pipeline (runs before whitespace collapsing/escaping)
- Carry charsmap bytes through isolate serialization (`_SerializableModelData`)
- Optimized hot-path: zero-copy pool reads, `addByte()` for single-byte passthrough, eliminated decode/re-encode round-trip

Closes #15

## Test plan

- [x] 19 new unit tests covering parsing, trie lookup, UTF-8 boundary handling, and SpNormalizer integration
- [x] `dart analyze` — no issues
- [x] Full test suite passes (all existing tests + new tests)
- [ ] Verify against a real model with precompiled_charsmap (e.g., Llama) and compare output with Python `sentencepiece`

https://claude.ai/code/session_01PaiDeY6VRz7Er9EzNPt39i